### PR TITLE
fix: bump hardcoded version in INSTALL.ts from 2.4 to 2.5

### DIFF
--- a/Releases/v2.5/.claude/INSTALL.ts
+++ b/Releases/v2.5/.claude/INSTALL.ts
@@ -295,7 +295,7 @@ function generateSettingsJson(config: InstallConfig): object {
 
   return {
     "$schema": "https://json.schemastore.org/claude-code-settings.json",
-    "paiVersion": "2.4",
+    "paiVersion": "2.5",
     "env": {
       "PAI_DIR": `${HOME}/.claude`,
       "PROJECTS_DIR": config.PROJECTS_DIR || "",
@@ -330,7 +330,7 @@ function generateSettingsJson(config: InstallConfig): object {
     },
     "pai": {
       "repoUrl": "github.com/danielmiessler/PAI",
-      "version": "2.4"
+      "version": "2.5"
     },
     "techStack": {
       "browser": "arc",


### PR DESCRIPTION
## Summary
- INSTALL.ts wizard writes `"2.4"` to settings.json, overwriting the correct `"2.5"` from the release template
- Two hardcoded version fields in `generateSettingsJson()` were never bumped

## Fix
- Line 298: `"paiVersion": "2.4"` → `"2.5"`
- Line 333: `"version": "2.4"` → `"2.5"`

## Test plan
- [x] Run `bun run INSTALL.ts` and verify `settings.json` contains `"version": "2.5"`
- [x] Run `pai` and confirm banner shows "PAI v2.5"

Fixes #612 (upstream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)