### PR TITLE
fix: use $HOME for SessionEnd hook paths

### DIFF
--- a/Releases/v2.5/.claude/INSTALL.ts
+++ b/Releases/v2.5/.claude/INSTALL.ts
@@ -376,8 +376,8 @@ function generateSettingsJson(config: InstallConfig): object {
       ],
       "SessionEnd": [
         { "hooks": [
-          { "type": "command", "command": "${PAI_DIR}/hooks/WorkCompletionLearning.hook.ts" },
-          { "type": "command", "command": "${PAI_DIR}/hooks/SessionSummary.hook.ts" }
+          { "type": "command", "command": "$HOME/.claude/hooks/WorkCompletionLearning.hook.ts" },
+          { "type": "command", "command": "$HOME/.claude/hooks/SessionSummary.hook.ts" }
         ]}
       ],
       "UserPromptSubmit": [

--- a/Releases/v2.5/.claude/settings.json
+++ b/Releases/v2.5/.claude/settings.json
@@ -163,11 +163,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${PAI_DIR}/hooks/WorkCompletionLearning.hook.ts"
+            "command": "$HOME/.claude/hooks/WorkCompletionLearning.hook.ts"
           },
           {
             "type": "command",
-            "command": "${PAI_DIR}/hooks/SessionSummary.hook.ts"
+            "command": "$HOME/.claude/hooks/SessionSummary.hook.ts"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- SessionEnd hooks fail because Claude Code doesn't inject `env` section variables (`${PAI_DIR}`) into the shell at session teardown
- Replaced `${PAI_DIR}` with `$HOME/.claude` for the two SessionEnd hooks — `$HOME` is always available as an OS-level env var
- Fixes both `settings.json` template and `INSTALL.ts` generator

Closes #13

## Test plan
- [ ] End a Claude Code session and verify no hook errors appear
- [ ] Run INSTALL.ts and verify generated settings.json has `$HOME/.claude` for SessionEnd hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)