### PR TITLE
Restore CorrectionMode fast-path and loadLatestSynthesis (hotfix)

### DIFF
--- a/Releases/v4.0.3+/.claude/hooks/RatingCapture.hook.ts
+++ b/Releases/v4.0.3+/.claude/hooks/RatingCapture.hook.ts
@@ -28,7 +28,7 @@
  * - Implicit sentiment path: 0.5-1.5s (Haiku inference)
  */
 
-import { appendFileSync, mkdirSync, existsSync, readFileSync, writeFileSync } from 'fs';
+import { appendFileSync, mkdirSync, existsSync, readFileSync, writeFileSync, openSync, readSync, closeSync } from 'fs';
 import { join } from 'path';
 import { codePath } from './lib/paths';
 import { getIdentity, getPrincipal, getPrincipalName } from './lib/identity';
@@ -68,6 +68,424 @@ const RATINGS_FILE = join(SIGNALS_DIR, 'ratings.jsonl');
 const LAST_RESPONSE_CACHE = join(BASE_DIR, 'MEMORY', 'STATE', 'last-response.txt');
 const MIN_PROMPT_LENGTH = 3;
 const MIN_CONFIDENCE = 0.5;
+
+// ── Behavioral Feedback Constants ──
+
+const BEHAVIORAL_FEEDBACK_STATE = join(BASE_DIR, 'MEMORY', 'STATE', 'behavioral-feedback.json');
+const BEHAVIORAL_SIGNALS_FILE = join(SIGNALS_DIR, 'behavioral-signals.jsonl');
+const CORRECTION_CONFIDENCE_THRESHOLD = 0.8;
+
+/**
+ * CorrectionMode — Fast-path correction detection.
+ *
+ * Detects explicit corrections in the user's prompt and emits a
+ * system-reminder forcing verification before edits. Runs BEFORE
+ * the slow sentiment analysis path.
+ *
+ * Patterns from council-approved spec (RatingCapture lines 192-195):
+ * - CORRECTIONS: "No, I meant..." / "That's not what I said" / "I said X not Y"
+ * - BEHAVIORAL CORRECTIONS: "Don't do that" / "Stop doing X" / "Never X"
+ * - REPEATED REQUESTS: Having to ask the same thing twice
+ *
+ * Explicitly excluded (refinements, not corrections):
+ * - "Actually, let's try Y" (direction change, not error correction)
+ * - "What about X?" (exploration, not correction)
+ * - "Can we also..." (addition, not correction)
+ */
+
+interface CorrectionDetection {
+  matched: boolean;
+  confidence: number;
+  pattern: 'negation_correction' | 'redirect' | 'behavioral' | 'repeated_request' | null;
+  promptPreview: string;
+}
+
+type BehaviorType =
+  | 'thorough-verification'
+  | 'clear-documentation'
+  | 'surgical-precision'
+  | 'iterative-improvement'
+  | 'evidence-based'
+  | 'working-output'
+  | 'good-communication'
+  | 'unclassified';
+
+interface BehavioralSignal {
+  timestamp: string;
+  session_id: string;
+  signal_id: string;
+  signal_type: 'correction' | 'reinforcement';
+  phase: 'triggered' | 'verified' | 'rated';
+  confidence: number;
+  pattern_matched?: 'negation_correction' | 'redirect' | 'behavioral' | 'repeated_request';
+  suppressed?: boolean;
+  suppressed_reason?: string;
+  rating?: number;
+  rating_source?: 'explicit' | 'implicit';
+  behavior_type?: BehaviorType;
+  behavior_summary?: string;
+  prompt_preview: string;
+  response_preview?: string;
+  outcome?: { delta_from_trigger: string };
+}
+
+interface BehavioralFeedbackState {
+  enabled: boolean;
+  verbose: boolean;
+  correction: {
+    enabled: boolean;
+    review_period_days: number;
+    auto_disabled_at: string | null;
+    auto_disabled_reason: string | null;
+    lifetime_corrections: number;
+    lifetime_false_positives: number;
+    review_started_at: string;
+    next_review_at: string;
+  };
+  reinforcement: {
+    enabled: boolean;
+    lifetime_reinforcements: number;
+    behavior_frequency: Record<string, number>;
+    top_behaviors: BehaviorType[];
+    last_reinforcement_at: string | null;
+    saturation_threshold: number;
+  };
+}
+
+// Correction patterns — high-precision regexes for explicit corrections only
+const CORRECTION_PATTERNS: Array<{
+  pattern: RegExp;
+  type: CorrectionDetection['pattern'];
+  confidence: number;
+}> = [
+  // "No, I meant X" / "No, I said X" / "That's not what I asked"
+  { pattern: /^no[,.]?\s+(i\s+(meant|said|asked|wanted)|that'?s?\s+not\s+what)/i, type: 'negation_correction', confidence: 0.92 },
+  // "I said X not Y" / "I asked for X not Y"
+  { pattern: /i\s+(said|asked\s+for|wanted|meant)\s+.+\s+not\s+/i, type: 'negation_correction', confidence: 0.88 },
+  // "That's wrong" / "That's incorrect" / "That's not right" / "That's not what I asked"
+  { pattern: /that'?s?\s+(wrong|incorrect|not\s+(right|correct|what\s+i))/i, type: 'negation_correction', confidence: 0.90 },
+  // "Don't do that" / "Stop doing X" / "Never do X" / "Don't X"
+  { pattern: /^(don'?t|stop|never)\s+(do\w*|add\w*|remov\w*|delet\w*|chang\w*|modif\w*|creat\w*|writ\w*)/i, type: 'behavioral', confidence: 0.85 },
+  // "You were supposed to X" / "You should have X"
+  { pattern: /you\s+(were\s+supposed|should\s+have|were\s+meant)\s+to/i, type: 'negation_correction', confidence: 0.87 },
+  // "This is still broken" / "This is still wrong" / "still not working"
+  { pattern: /(still\s+(broken|wrong|not\s+work|failing|happen)|keeps?\s+(happen|break|fail))/i, type: 'repeated_request', confidence: 0.85 },
+  // "How many times" / "I keep telling you" / "I already said"
+  { pattern: /(how\s+many\s+times|i\s+keep\s+tell|i\s+already\s+(said|told|asked))/i, type: 'repeated_request', confidence: 0.90 },
+];
+
+// Refinement exclusion patterns — if these match, it's NOT a correction
+const REFINEMENT_PATTERNS: RegExp[] = [
+  /^actually,?\s+let'?s?\s+(try|go\s+with|use|switch)/i,
+  /^what\s+about\s/i,
+  /^can\s+we\s+(also|add|try)/i,
+  /^let'?s?\s+(also|try|switch|change\s+to)/i,
+  /^(instead|rather),?\s+(let'?s?|can\s+we|how\s+about)/i,
+];
+
+// ── ReinforcementMode: Behavior Classification ──
+
+const BEHAVIOR_MARKERS: Array<{
+  pattern: RegExp;
+  behavior: BehaviorType;
+  confidence: number;
+}> = [
+  { pattern: /✅\s*VERIFY/, behavior: 'thorough-verification', confidence: 0.90 },
+  { pattern: /\b(diff|verified|confirmed|checked|tested)\b/i, behavior: 'thorough-verification', confidence: 0.85 },
+  { pattern: /\b(report|doc|summary|wrote|documented)\b.*\b(created|saved|written)\b/i, behavior: 'clear-documentation', confidence: 0.80 },
+  { pattern: /\b(1-line|single|minimal|targeted|surgical)\b.*\b(fix|change|patch|diff)\b/i, behavior: 'surgical-precision', confidence: 0.85 },
+  { pattern: /🔄\s*ITERATION/, behavior: 'iterative-improvement', confidence: 0.85 },
+  { pattern: /\b(cited|referenced|linked|source|evidence|API response)\b/i, behavior: 'evidence-based', confidence: 0.80 },
+  { pattern: /\b(deployed|running|working|functional|live|posted)\b/i, behavior: 'working-output', confidence: 0.75 },
+];
+
+function classifyBehavior(
+  responsePreview: string,
+  prompt: string,
+  comment?: string
+): { behavior_type: BehaviorType; behavior_summary: string; confidence: number } {
+  const text = [responsePreview, prompt, comment].filter(Boolean).join(' ');
+
+  for (const { pattern, behavior, confidence } of BEHAVIOR_MARKERS) {
+    if (pattern.test(text)) {
+      return {
+        behavior_type: behavior,
+        behavior_summary: safeSlice(text, 80),
+        confidence,
+      };
+    }
+  }
+
+  return { behavior_type: 'unclassified', behavior_summary: '', confidence: 0.5 };
+}
+
+// Track session reinforcement count (in-memory, resets per hook invocation)
+let sessionReinforcementCount = 0;
+
+function shouldCaptureReinforcement(
+  state: BehavioralFeedbackState,
+  behaviorType: BehaviorType,
+  confidence: number,
+): { capture: boolean; reason?: string } {
+  if (!state.enabled || !state.reinforcement.enabled) {
+    return { capture: false, reason: 'disabled' };
+  }
+  if (confidence < 0.7) {
+    return { capture: false, reason: 'low_confidence' };
+  }
+  if (sessionReinforcementCount >= 3) {
+    return { capture: false, reason: 'session_cap' };
+  }
+  const freq = state.reinforcement.behavior_frequency[behaviorType] || 0;
+  if (freq >= state.reinforcement.saturation_threshold) {
+    return { capture: false, reason: 'saturated' };
+  }
+  return { capture: true };
+}
+
+function generateReinforcementId(): string {
+  return generateSignalId('reinf');
+}
+
+function updateReinforcementState(state: BehavioralFeedbackState, behaviorType: BehaviorType): void {
+  state.reinforcement.lifetime_reinforcements++;
+  state.reinforcement.behavior_frequency[behaviorType] =
+    (state.reinforcement.behavior_frequency[behaviorType] || 0) + 1;
+  state.reinforcement.last_reinforcement_at = getISOTimestamp();
+
+  // Recalculate top_behaviors (sorted by frequency, top 5)
+  const sorted = Object.entries(state.reinforcement.behavior_frequency)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5)
+    .map(([type]) => type as BehaviorType);
+  state.reinforcement.top_behaviors = sorted;
+
+  writeFileSync(BEHAVIORAL_FEEDBACK_STATE, JSON.stringify(state, null, 2), 'utf-8');
+}
+
+async function captureReinforcement(
+  rating: number,
+  source: 'explicit' | 'implicit',
+  prompt: string,
+  responsePreview: string,
+  sessionId: string,
+  comment?: string,
+): Promise<void> {
+  if (rating < 8) return;
+
+  const state = loadBehavioralFeedbackState();
+  if (!state?.reinforcement?.enabled) return;
+
+  const classification = classifyBehavior(responsePreview, prompt, comment);
+
+  const guard = shouldCaptureReinforcement(state, classification.behavior_type, classification.confidence);
+  if (!guard.capture) {
+    console.error(`[ReinforcementMode] Skipped (${guard.reason})`);
+    return;
+  }
+
+  writeBehavioralSignal({
+    timestamp: getISOTimestamp(),
+    session_id: sessionId,
+    signal_id: generateReinforcementId(),
+    signal_type: 'reinforcement',
+    phase: 'triggered',
+    confidence: classification.confidence,
+    rating,
+    rating_source: source,
+    behavior_type: classification.behavior_type,
+    behavior_summary: classification.behavior_summary,
+    prompt_preview: safeSlice(prompt.trim(), 60),
+    response_preview: safeSlice(responsePreview, 500),
+  });
+
+  sessionReinforcementCount++;
+  updateReinforcementState(state, classification.behavior_type);
+
+  console.error(
+    `[ReinforcementMode] Captured: ${classification.behavior_type} ` +
+    `(${classification.confidence}) for rating ${rating}`
+  );
+}
+
+function detectCorrection(prompt: string): CorrectionDetection {
+  const trimmed = prompt.trim();
+  const preview = trimmed.length > 60 ? safeSlice(trimmed, 57) + '...' : trimmed;
+
+  // Check refinement exclusions first
+  for (const refinement of REFINEMENT_PATTERNS) {
+    if (refinement.test(trimmed)) {
+      return { matched: false, confidence: 0, pattern: null, promptPreview: preview };
+    }
+  }
+
+  // Check correction patterns
+  for (const { pattern, type, confidence } of CORRECTION_PATTERNS) {
+    if (pattern.test(trimmed)) {
+      return { matched: true, confidence, pattern: type, promptPreview: preview };
+    }
+  }
+
+  return { matched: false, confidence: 0, pattern: null, promptPreview: preview };
+}
+
+function loadBehavioralFeedbackState(): BehavioralFeedbackState | null {
+  try {
+    if (!existsSync(BEHAVIORAL_FEEDBACK_STATE)) return null;
+    return JSON.parse(readFileSync(BEHAVIORAL_FEEDBACK_STATE, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+function checkKillSwitch(): { active: boolean; reason?: string; state?: BehavioralFeedbackState } {
+  const state = loadBehavioralFeedbackState();
+  if (!state) return { active: false, reason: 'no_state_file' };
+  if (!state.enabled || !state.correction.enabled) return { active: false, reason: state.correction.auto_disabled_reason || 'disabled' };
+
+  // Check rolling 20 rated entries for kill-switch
+  try {
+    if (!existsSync(BEHAVIORAL_SIGNALS_FILE)) return { active: true, state };
+
+    // Tail-read optimization: read only the last ~4KB instead of the entire file.
+    // Each JSONL line is ~300 bytes, so 4KB covers ~13 entries — enough for rolling checks.
+    const fd = Bun.file(BEHAVIORAL_SIGNALS_FILE);
+    const fileSize = fd.size;
+    const tailSize = Math.min(fileSize, 4096);
+    const buffer = new Uint8Array(tailSize);
+    const fh = openSync(BEHAVIORAL_SIGNALS_FILE, 'r');
+    readSync(fh, buffer, 0, tailSize, Math.max(0, fileSize - tailSize));
+    closeSync(fh);
+
+    const tailContent = new TextDecoder().decode(buffer);
+    const lines = tailContent.split('\n').filter(Boolean);
+    // First line may be partial if we didn't start at file beginning
+    if (fileSize > tailSize && lines.length > 0) lines.shift();
+
+    const entries = lines
+      .map(l => { try { return JSON.parse(l); } catch { return null; } })
+      .filter(Boolean);
+
+    const rated = entries.filter((e: any) => e.phase === 'rated').slice(-20);
+
+    // Need minimum 5 rated entries for kill-switch to evaluate
+    if (rated.length < 5) return { active: true, state };
+
+    // Check rolling average delta
+    const deltas = rated.map((e: any) => parseFloat(e.outcome?.delta_from_trigger || '0'));
+    const avgDelta = deltas.reduce((a: number, b: number) => a + b, 0) / deltas.length;
+    if (avgDelta <= 0) {
+      return { active: false, reason: 'killswitch_delta', state };
+    }
+
+    // Check consecutive false positives (3 in a row)
+    const recentRated = rated.slice(-3);
+    if (recentRated.length === 3 && recentRated.every((e: any) => {
+      const delta = parseFloat(e.outcome?.delta_from_trigger || '0');
+      return delta <= 0;
+    })) {
+      return { active: false, reason: 'consecutive_false_positives', state };
+    }
+
+    return { active: true, state };
+  } catch {
+    return { active: true, state }; // Fail open on read errors
+  }
+}
+
+function writeBehavioralSignal(entry: Record<string, unknown>): void {
+  mkdirSync(SIGNALS_DIR, { recursive: true });
+  appendFileSync(BEHAVIORAL_SIGNALS_FILE, JSON.stringify(entry) + '\n', 'utf-8');
+}
+
+function generateSignalId(prefix: string): string {
+  const { year, month, day, hours, minutes, seconds } = getPSTComponents();
+  return `${prefix}_${year}${month}${day}_${hours}${minutes}${seconds}`;
+}
+
+function generateCorrectionId(): string {
+  return generateSignalId('corr');
+}
+
+/**
+ * CorrectionMode fast-path — runs BEFORE sentiment analysis.
+ * Returns true if a correction was detected (processing continues regardless).
+ */
+function runCorrectionMode(prompt: string, sessionId: string): boolean {
+  const detection = detectCorrection(prompt);
+
+  if (!detection.matched || detection.confidence < CORRECTION_CONFIDENCE_THRESHOLD) {
+    // Log suppressed detection if it was close (confidence 0.6-0.79)
+    if (detection.matched && detection.confidence >= 0.6) {
+      writeBehavioralSignal({
+        timestamp: getISOTimestamp(),
+        session_id: sessionId,
+        signal_id: generateCorrectionId(),
+        signal_type: 'correction',
+        phase: 'triggered',
+        confidence: detection.confidence,
+        suppressed: true,
+        suppressed_reason: 'below_threshold',
+        prompt_preview: detection.promptPreview,
+        pattern_matched: detection.pattern,
+      });
+      console.error(`[CorrectionMode] Suppressed (confidence ${detection.confidence} < ${CORRECTION_CONFIDENCE_THRESHOLD}): "${detection.promptPreview}"`);
+    }
+    return false;
+  }
+
+  // Kill-switch check
+  const killSwitch = checkKillSwitch();
+  if (!killSwitch.active) {
+    writeBehavioralSignal({
+      timestamp: getISOTimestamp(),
+      session_id: sessionId,
+      signal_id: generateCorrectionId(),
+      signal_type: 'correction',
+      phase: 'triggered',
+      confidence: detection.confidence,
+      suppressed: true,
+      suppressed_reason: killSwitch.reason,
+      prompt_preview: detection.promptPreview,
+      pattern_matched: detection.pattern,
+    });
+    console.error(`[CorrectionMode] Suppressed (kill-switch: ${killSwitch.reason}): "${detection.promptPreview}"`);
+    return false;
+  }
+
+  // EMIT system-reminder — this is the behavioral intervention
+  const correctionId = generateCorrectionId();
+  console.log(`<system-reminder>
+CORRECTION DETECTED — verify before editing. Use Read/Grep to confirm current state before any Edit/Write. Re-read the request carefully.
+</system-reminder>`);
+
+  // Log triggered entry
+  writeBehavioralSignal({
+    timestamp: getISOTimestamp(),
+    session_id: sessionId,
+    signal_id: correctionId,
+    signal_type: 'correction',
+    phase: 'triggered',
+    confidence: detection.confidence,
+    suppressed: false,
+    prompt_preview: detection.promptPreview,
+    pattern_matched: detection.pattern,
+  });
+
+  // Update state file lifetime count (reuse state from kill-switch check)
+  try {
+    const state = killSwitch.state;
+    if (state) {
+      state.correction.lifetime_corrections++;
+      writeFileSync(BEHAVIORAL_FEEDBACK_STATE, JSON.stringify(state, null, 2), 'utf-8');
+    }
+  } catch {
+    console.error('[CorrectionMode] Failed to update state file');
+  }
+
+  console.error(`[CorrectionMode] FIRED (${detection.pattern}, confidence ${detection.confidence}): "${detection.promptPreview}"`);
+  return true;
+}
 
 /**
  * Safely slices a string, ensuring it doesn't split a UTF-16 surrogate pair.
@@ -406,6 +824,8 @@ async function main() {
 
       writeRating(entry);
 
+      // ReinforcementMode: capture positive explicit ratings
+      await captureReinforcement(explicitResult.rating, 'explicit', prompt, cachedResponse || '', data.session_id, explicitResult.comment);
 
       if (explicitResult.rating < 5) {
         // Read cached last response (written by LastResponseCache.hook.ts on previous Stop event)
@@ -430,6 +850,17 @@ async function main() {
       }
 
       process.exit(0);
+    }
+
+    // ── CorrectionMode Fast-Path (runs before sentiment, ~5ms) ──
+    // Detects explicit corrections and emits system-reminder.
+    // Does NOT exit — sentiment analysis continues after this.
+    if (prompt.length >= MIN_PROMPT_LENGTH) {
+      try {
+        runCorrectionMode(prompt, data.session_id);
+      } catch (err) {
+        console.error(`[CorrectionMode] Error in fast-path: ${err}`);
+      }
     }
 
     // ── Path 2: Implicit Sentiment ──
@@ -480,7 +911,10 @@ async function main() {
           confidence: 0.95,
           ...(cachedResponse ? { response_preview: safeSlice(cachedResponse, 500) } : {}),
         });
-  
+
+        // ReinforcementMode: capture praise fast-path
+        await captureReinforcement(8, 'implicit', prompt, cachedResponse || '', data.session_id);
+
         process.exit(0);
       }
     }
@@ -522,6 +956,8 @@ async function main() {
 
       writeRating(entry);
 
+      // ReinforcementMode: capture positive implicit ratings
+      await captureReinforcement(sentiment.rating, 'implicit', prompt, implicitCachedResponse || '', data.session_id, undefined);
 
       if (sentiment.rating < 5) {
         captureLowRatingLearning(

--- a/Releases/v4.0.3+/.claude/hooks/lib/learning-readback.ts
+++ b/Releases/v4.0.3+/.claude/hooks/lib/learning-readback.ts
@@ -24,15 +24,16 @@
 
 import { readFileSync, existsSync, readdirSync } from 'fs';
 import { join } from 'path';
+import { codePath } from './paths';
 
 /**
  * Read the N most recent learning files from a LEARNING subdirectory.
  * Files are named YYYY-MM-DD-HHMMSS_LEARNING_*.md with YAML frontmatter.
  * Extracts the **Feedback:** line and rating for compact display.
  */
-function getRecentLearnings(baseDir: string, subdir: string, count: number): string[] {
+function getRecentLearnings(subdir: string, count: number): string[] {
   const insights: string[] = [];
-  const learningDir = join(baseDir, 'MEMORY', 'LEARNING', subdir);
+  const learningDir = codePath('MEMORY', 'LEARNING', subdir);
   if (!existsSync(learningDir)) return insights;
 
   try {
@@ -77,9 +78,9 @@ function getRecentLearnings(baseDir: string, subdir: string, count: number): str
  * Load recent learning signals from ALGORITHM and SYSTEM directories.
  * Returns the 3 most recent from each, formatted as a compact bullet list.
  */
-export function loadLearningDigest(paiDir: string): string | null {
-  const algorithmInsights = getRecentLearnings(paiDir, 'ALGORITHM', 3);
-  const systemInsights = getRecentLearnings(paiDir, 'SYSTEM', 3);
+export function loadLearningDigest(): string | null {
+  const algorithmInsights = getRecentLearnings('ALGORITHM', 3);
+  const systemInsights = getRecentLearnings('SYSTEM', 3);
 
   if (algorithmInsights.length === 0 && systemInsights.length === 0) return null;
 
@@ -102,8 +103,8 @@ export function loadLearningDigest(paiDir: string): string | null {
  * Reads all WISDOM/FRAMES/*.md files and extracts principle headers
  * (lines matching "### Name [CRYSTAL: N%]").
  */
-export function loadWisdomFrames(paiDir: string): string | null {
-  const framesDir = join(paiDir, 'MEMORY', 'WISDOM', 'FRAMES');
+export function loadWisdomFrames(): string | null {
+  const framesDir = codePath('MEMORY', 'WISDOM', 'FRAMES');
   if (!existsSync(framesDir)) return null;
 
   const principles: string[] = [];
@@ -138,8 +139,8 @@ export function loadWisdomFrames(paiDir: string): string | null {
  * Reads the 5 most recent FAILURES directories and extracts the CONTEXT.md
  * first paragraph for a compact summary of what went wrong.
  */
-export function loadFailurePatterns(paiDir: string): string | null {
-  const failuresDir = join(paiDir, 'MEMORY', 'LEARNING', 'FAILURES');
+export function loadFailurePatterns(): string | null {
+  const failuresDir = codePath('MEMORY', 'LEARNING', 'FAILURES');
   if (!existsSync(failuresDir)) return null;
 
   const patterns: string[] = [];
@@ -192,8 +193,8 @@ export function loadFailurePatterns(paiDir: string): string | null {
  * Load performance signal trends from the pre-computed learning-cache.sh.
  * Extracts numeric averages and trend direction for a compact status line.
  */
-export function loadSignalTrends(paiDir: string): string | null {
-  const cachePath = join(paiDir, 'MEMORY', 'STATE', 'learning-cache.sh');
+export function loadSignalTrends(): string | null {
+  const cachePath = codePath('MEMORY', 'STATE', 'learning-cache.sh');
   if (!existsSync(cachePath)) return null;
 
   try {
@@ -216,6 +217,166 @@ export function loadSignalTrends(paiDir: string): string | null {
     const trendEmoji = trend === 'up' ? 'trending up' : trend === 'down' ? 'trending down' : 'stable';
 
     return `**Performance Signals:** Today: ${todayAvg}/10 | Week: ${weekAvg}/10 | Month: ${monthAvg}/10 | Trend: ${trendEmoji} | Total signals: ${totalCount}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load the most recent synthesis report for context injection.
+ * Reads from LEARNING/SYNTHESIS/ monthly directories, returns a compact
+ * summary of the latest pattern analysis. Cap at 256 tokens (~1000 chars).
+ */
+export function loadLatestSynthesis(): string | null {
+  const synthesisDir = codePath('MEMORY', 'LEARNING', 'SYNTHESIS');
+  if (!existsSync(synthesisDir)) return null;
+
+  try {
+    // Get month dirs sorted descending (newest first)
+    const months = readdirSync(synthesisDir, { withFileTypes: true })
+      .filter(d => d.isDirectory() && /^\d{4}-\d{2}$/.test(d.name))
+      .map(d => d.name)
+      .sort()
+      .reverse();
+
+    for (const month of months) {
+      const monthPath = join(synthesisDir, month);
+      try {
+        const files = readdirSync(monthPath)
+          .filter(f => f.endsWith('.md'))
+          .sort()
+          .reverse();
+
+        if (files.length === 0) continue;
+
+        // Read the most recent synthesis file
+        const content = readFileSync(join(monthPath, files[0]), 'utf-8');
+
+        // Extract key sections compactly
+        const parts: string[] = [];
+
+        // Extract period and avg rating
+        const periodMatch = content.match(/\*\*Period:\*\*\s*(.+)/);
+        const avgMatch = content.match(/\*\*Average Rating:\*\*\s*(.+)/);
+        if (periodMatch) parts.push(`Period: ${periodMatch[1]}`);
+        if (avgMatch) parts.push(`Avg: ${avgMatch[1]}`);
+
+        // Extract top issues (most valuable for context)
+        const issuesSection = content.match(/## Top Issues\n\n([\s\S]*?)(?=\n##|\n---)/);
+        if (issuesSection && !issuesSection[1].includes('No significant issues')) {
+          const issues = issuesSection[1].trim().split('\n')
+            .filter(l => l.match(/^\d+\./))
+            .map(l => l.replace(/^\d+\.\s*/, '').substring(0, 80))
+            .slice(0, 3);
+          if (issues.length > 0) {
+            parts.push('Top issues:');
+            issues.forEach(i => parts.push(`  - ${i}`));
+          }
+        }
+
+        // Extract recommendations
+        const recsSection = content.match(/## Recommendations\n\n([\s\S]*?)(?=\n---)/);
+        if (recsSection) {
+          const recs = recsSection[1].trim().split('\n')
+            .filter(l => l.match(/^\d+\./))
+            .map(l => l.replace(/^\d+\.\s*/, '').substring(0, 80))
+            .slice(0, 3);
+          if (recs.length > 0) {
+            parts.push('Recommendations:');
+            recs.forEach(r => parts.push(`  - ${r}`));
+          }
+        }
+
+        if (parts.length === 0) return null;
+
+        const result = `**Latest Synthesis:**\n${parts.join('\n')}`;
+        // Hard cap at ~1000 chars (256 tokens)
+        return result.length > 1000 ? result.substring(0, 997) + '...' : result;
+      } catch { /* skip unreadable months */ }
+    }
+  } catch { /* skip if dir scan fails */ }
+
+  return null;
+}
+
+/**
+ * Load unified behavioral feedback trends for context injection.
+ * Reads behavioral-feedback.json state and behavioral-signals.jsonl entries
+ * to produce a compact summary of correction + reinforcement system health.
+ */
+export function loadBehavioralTrends(): string | null {
+  const statePath = codePath('MEMORY', 'STATE', 'behavioral-feedback.json');
+  if (!existsSync(statePath)) return null;
+
+  try {
+    const state = JSON.parse(readFileSync(statePath, 'utf-8'));
+    if (!state.enabled) return null;
+
+    const signalsPath = codePath('MEMORY', 'LEARNING', 'SIGNALS', 'behavioral-signals.jsonl');
+    let correctionTriggers = 0;
+    let correctionVerified = 0;
+    let avgDelta = 0;
+    let ratedCount = 0;
+    let reinforcementCount = 0;
+    let latestReinforcement: { summary: string; rating: number } | null = null;
+
+    if (existsSync(signalsPath)) {
+      const lines = readFileSync(signalsPath, 'utf-8').trim().split('\n').filter(Boolean);
+      const entries = lines.map(l => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
+
+      // Correction stats
+      const corrections = entries.filter((e: any) => e.signal_type === 'correction');
+      correctionTriggers = corrections.filter((e: any) => e.phase === 'triggered' && !e.suppressed).length;
+      correctionVerified = corrections.filter((e: any) => e.phase === 'verified').length;
+      const rated = corrections.filter((e: any) => e.phase === 'rated');
+      ratedCount = rated.length;
+      if (ratedCount > 0) {
+        const deltas = rated.map((e: any) => parseFloat(e.outcome?.delta_from_trigger || '0'));
+        avgDelta = deltas.reduce((a: number, b: number) => a + b, 0) / deltas.length;
+      }
+
+      // Reinforcement stats
+      const reinforcements = entries.filter((e: any) => e.signal_type === 'reinforcement');
+      reinforcementCount = reinforcements.length;
+      if (reinforcements.length > 0) {
+        const latest = reinforcements[reinforcements.length - 1];
+        latestReinforcement = {
+          summary: latest.behavior_summary || latest.behavior_type || 'unknown',
+          rating: latest.rating || 0,
+        };
+      }
+    }
+
+    const parts: string[] = [];
+
+    // Correction section
+    const corrStatus = state.correction.enabled ? 'ACTIVE' : `DISABLED (${state.correction.auto_disabled_reason || 'manual'})`;
+    if (correctionTriggers > 0) {
+      const compliance = Math.round((correctionVerified / correctionTriggers) * 100);
+      parts.push(`Corrections: ${correctionTriggers} triggers, ${compliance}% compliance, ${avgDelta > 0 ? '+' : ''}${avgDelta.toFixed(1)} delta, ${corrStatus}`);
+    } else {
+      parts.push(`Corrections: ${corrStatus}, none yet`);
+    }
+
+    // Reinforcement section
+    if (reinforcementCount > 0) {
+      const topBehaviors = (state.reinforcement?.top_behaviors || []).slice(0, 3);
+      const freqs = state.reinforcement?.behavior_frequency || {};
+      const topStr = topBehaviors.map((b: string) => `${b} (${freqs[b] || 0})`).join(', ');
+      let reinfLine = `Reinforcements: ${reinforcementCount} signals`;
+      if (topStr) reinfLine += ` | Top: ${topStr}`;
+      if (latestReinforcement) {
+        const summary = latestReinforcement.summary.length > 40
+          ? latestReinforcement.summary.substring(0, 37) + '...'
+          : latestReinforcement.summary;
+        reinfLine += ` | Latest: "${summary}" (${latestReinforcement.rating}/10)`;
+      }
+      parts.push(reinfLine);
+    } else {
+      parts.push('Reinforcements: none yet');
+    }
+
+    return `**Behavioral Feedback:** ${parts.join(' | ')}`;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

Emergency hotfix for a 606-line functional regression that shipped to `main` via #101.

**The regression.** PR #101's squash-merge bundled commit `ebc8130` ("Implement CLAUDE_CONFIG_DIR + PAI_DIR two-root separation in release template"), whose commit message described only the path-separation intent. The same commit also silently deleted ~606 lines of unrelated functionality:

- `RatingCapture.hook.ts`: `CorrectionMode` fast-path, `BehavioralSignal` capture, and the `BEHAVIORAL_FEEDBACK_STATE` subsystem (~446 lines)
- `learning-readback.ts`: `loadLatestSynthesis` reader (~160 lines)

**Evidence on main (pre-hotfix).**
- `origin/main:RatingCapture.hook.ts` — 568 lines, **zero** matches for `CorrectionMode|BehavioralSignal`
- `origin/main:learning-readback.ts` — 222 lines, header docstring lists only 4 functions (no `loadLatestSynthesis`)

**Runtime impact.** Users on `main` boot every session with:
- No correction-mode fast path (rating-with-correction flow dead)
- No behavioral-signal capture (learning loop broken at the signal stage)
- No synthesis digest in `LoadContext` (session cold-starts without accumulated knowledge)
- Anyone upgrading from v4.0.2 also silently loses access to their existing correction history.

**The fix.** Restore the two files from branch `100-claude-config-dir-pai-dir-separation` (commit `42f70b4` "Fix two-root path bugs and revert ebc8130 scope-creep deletions"). Both files already use `codePath()` from the two-root `paths.ts` that landed with #101, so no further path-separation work is pulled in.

**Scope.** 2 files, +610 / -13. No architecture change, no new dependencies, no API change on top of what #101 already exposed.

## Verification

- [x] `bun build` clean on both files (`Releases/v4.0.3+/.claude/hooks/RatingCapture.hook.ts`, `Releases/v4.0.3+/.claude/hooks/lib/learning-readback.ts`)
- [x] `RatingCapture.hook.ts` contains 21 matches for `CorrectionMode|BehavioralSignal|BEHAVIORAL_FEEDBACK_STATE`
- [x] `learning-readback.ts` exports `loadLatestSynthesis`
- [x] Imports resolve against `main`'s `paths.ts` (`codePath` only)

## Test plan

- [ ] Trigger CorrectionMode path with a rating-with-correction, confirm `RatingCapture` fires the fast-path
- [ ] Confirm `BehavioralSignal` writes land in `$PAI_DIR/MEMORY/`
- [ ] Run `LoadContext.hook.ts` end-to-end and confirm `loadLatestSynthesis` returns synthesis content
- [ ] Spot-check that no unrelated hook behaviour regressed

## Relationship to PR #103

This hotfix is deliberately **narrow and orthogonal** to PR #103 (`100-claude-config-dir-pai-dir-separation`). PR #103 is currently `CONFLICTING` against main and bundles this restore together with 7 further path-separation bug fixes, a `paiPath()` deprecation, and architectural deferrals. That PR should be rebased against this hotfixed main so its diff collapses to the refactor work alone.

## Recommended follow-up (not in this PR)

Add a minimal CI guard that fails PRs if `RatingCapture.hook.ts` loses its `CorrectionMode`/`BehavioralSignal` symbols or `learning-readback.ts` loses `loadLatestSynthesis` without an allowlist entry. Exactly this class of unannounced deletion is what #101 shipped.