### PR TITLE
Add CI symbol guard for critical hook files

### DIFF
--- a/.github/workflows/hook-symbol-guard.yml
+++ b/.github/workflows/hook-symbol-guard.yml
@@ -1,0 +1,86 @@
+name: Hook Symbol Guard
+
+on:
+  pull_request:
+    paths:
+      - 'Releases/*/.claude/hooks/**'
+      - '.github/workflows/hook-symbol-guard.yml'
+
+jobs:
+  symbol-guard:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Bun build critical hook files
+        run: |
+          set -eo pipefail
+          files=(
+            "Releases/v4.0.3+/.claude/hooks/RatingCapture.hook.ts"
+            "Releases/v4.0.3+/.claude/hooks/lib/learning-readback.ts"
+            "Releases/v4.0.3+/.claude/hooks/lib/paths.ts"
+            "Releases/v4.0.3+/.claude/hooks/LoadContext.hook.ts"
+          )
+          for f in "${files[@]}"; do
+            if [ -f "$f" ]; then
+              bun build --target=bun "$f" --outdir /tmp/guard-build > /dev/null
+              echo "build OK: $f"
+            else
+              echo "skip (not present): $f"
+            fi
+          done
+
+      - name: Assert required symbols present
+        run: |
+          set -eo pipefail
+          fail=0
+          check() {
+            local file="$1" symbol="$2"
+            if [ ! -f "$file" ]; then
+              echo "skip (not present): $file"
+              return 0
+            fi
+            if ! grep -q "$symbol" "$file"; then
+              echo "::error file=$file::required symbol '$symbol' is missing - was it unintentionally deleted?"
+              fail=1
+            else
+              echo "symbol OK: $file :: $symbol"
+            fi
+          }
+
+          # RatingCapture subsystems that have been silently deleted before
+          # (see PR #101 -> PR #104 restoration). Any PR that drops one of
+          # these symbols without a matching allowlist bump must be examined.
+          check "Releases/v4.0.3+/.claude/hooks/RatingCapture.hook.ts" "CorrectionMode"
+          check "Releases/v4.0.3+/.claude/hooks/RatingCapture.hook.ts" "BehavioralSignal"
+          check "Releases/v4.0.3+/.claude/hooks/RatingCapture.hook.ts" "BEHAVIORAL_FEEDBACK_STATE"
+
+          # learning-readback functions consumed by LoadContext at session start.
+          check "Releases/v4.0.3+/.claude/hooks/lib/learning-readback.ts" "loadLatestSynthesis"
+          check "Releases/v4.0.3+/.claude/hooks/lib/learning-readback.ts" "loadBehavioralTrends"
+          check "Releases/v4.0.3+/.claude/hooks/lib/learning-readback.ts" "loadLearningDigest"
+          check "Releases/v4.0.3+/.claude/hooks/lib/learning-readback.ts" "loadWisdomFrames"
+          check "Releases/v4.0.3+/.claude/hooks/lib/learning-readback.ts" "loadFailurePatterns"
+          check "Releases/v4.0.3+/.claude/hooks/lib/learning-readback.ts" "loadSignalTrends"
+
+          # Two-root path primitives - removing any of these is a breaking change.
+          check "Releases/v4.0.3+/.claude/hooks/lib/paths.ts" "getConfigDir"
+          check "Releases/v4.0.3+/.claude/hooks/lib/paths.ts" "getPaiDir"
+          check "Releases/v4.0.3+/.claude/hooks/lib/paths.ts" "configPath"
+          check "Releases/v4.0.3+/.claude/hooks/lib/paths.ts" "codePath"
+
+          if [ "$fail" -ne 0 ]; then
+            echo ""
+            echo "One or more required symbols are missing. If you are intentionally"
+            echo "removing a symbol, update this workflow in the same PR and justify"
+            echo "the removal in the PR description."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Adds `.github/workflows/hook-symbol-guard.yml` — a minimal CI job that fails PRs touching `Releases/*/.claude/hooks/**` if either of the following is true:

1. `bun build --target=bun` fails on any of the critical hook files (`RatingCapture.hook.ts`, `learning-readback.ts`, `paths.ts`, `LoadContext.hook.ts`).
2. Any of the named symbols below is missing from the file it's expected in.

## Motivation

PR #101 squash-merged a four-commit change into `main` whose bundled commit `ebc8130` silently deleted ~606 lines of unrelated functionality (`CorrectionMode` fast-path, `BehavioralSignal` capture, `loadLatestSynthesis`). PR #104 restored those files, but nothing structural prevents the same class of failure from happening again.

This workflow is the structural fix: a deletion of any guarded symbol — whether by a human, an agent, or an IDE refactor — fails the PR with a clear message before review.

## Guarded symbols

| File | Symbols |
|------|---------|
| `RatingCapture.hook.ts` | `CorrectionMode`, `BehavioralSignal`, `BEHAVIORAL_FEEDBACK_STATE` |
| `lib/learning-readback.ts` | `loadLatestSynthesis`, `loadBehavioralTrends`, `loadLearningDigest`, `loadWisdomFrames`, `loadFailurePatterns`, `loadSignalTrends` |
| `lib/paths.ts` | `getConfigDir`, `getPaiDir`, `configPath`, `codePath` |

13 symbol checks total.

## How to remove a symbol legitimately

If a future PR needs to remove a guarded symbol on purpose, the contract is: **update this workflow in the same PR** to remove the symbol from the check list, and justify the removal in the PR description. The grep check is deliberately simple so this escape hatch is obvious.

## Scope and cost

- 1 file, +86 lines, no runtime dependency.
- Path-scoped trigger — only fires on PRs touching the release hooks tree or this workflow itself, so unrelated PRs don't pay the CI cost.
- No secrets required. No external network calls except `actions/checkout@v4` and `oven-sh/setup-bun@v2`.
- Total expected CI time: under 45 seconds.

## Self-test evidence (from local working tree on fresh `origin/main`)

- `bun yaml parse` on the workflow file: valid, 4 steps detected.
- All 13 symbol checks pass on current `origin/main`.
- `bun build --target=bun` clean on all 4 critical files.

## Known limitations

- `Releases/v4.0.3+/` is hard-coded. When a future `Releases/v4.0.4+/` tree appears, this workflow will need updating. That's an intentional simplification — much better to maintain a short explicit list than to ship a clever-but-brittle glob.
- Symbol checks are grep-based, not AST-based. A symbol that survives only inside a comment would pass the check. Acceptable tradeoff for this use case: the intent is to catch *accidental* deletion, and an accidentally-commented-out critical symbol would also be caught by the `bun build` step when its call sites break.