### PR TITLE
Complete two-root path separation (supersedes #103)

### DIFF
--- a/.pai-protected.json
+++ b/.pai-protected.json
@@ -398,8 +398,6 @@
           "USER/",
           "USER directory",
           "USER tier",
-          "~/.claude/skills",
-          "~/.claude/hooks",
           "$PAI_DIR/skills",
           "$PAI_DIR/hooks",
           "ANTHROPIC_API_KEY=your",
@@ -417,7 +415,7 @@
   "kai_to_pai_workflow": {
     "description": "How to safely sync Kai improvements to PAI",
     "steps": [
-      "1. Make changes in Kai (~/.claude/)",
+      "1. Make changes in Kai (~/.claude/ + ~/.pai/ under the two-root split)",
       "2. Test thoroughly in Kai environment",
       "3. Identify which changes should go to public PAI",
       "4. Copy changes to PAI repo (~/Projects/PAI/)",

--- a/Releases/v4.0.3+/.claude/PAI/SYSTEM_USER_EXTENDABILITY.md
+++ b/Releases/v4.0.3+/.claude/PAI/SYSTEM_USER_EXTENDABILITY.md
@@ -164,10 +164,10 @@ When creating a new configurable component:
 3. **Implement cascading lookup**
    ```typescript
    function getConfigPath(): string | null {
-     const userPath = paiPath('USER', 'ComponentName', 'config.yaml');
+     const userPath = codePath('USER', 'ComponentName', 'config.yaml');
      if (existsSync(userPath)) return userPath;
 
-     const systemPath = paiPath('ComponentName', 'config.example.yaml');
+     const systemPath = codePath('ComponentName', 'config.example.yaml');
      if (existsSync(systemPath)) return systemPath;
 
      return null;  // Will use hardcoded defaults
@@ -196,8 +196,8 @@ To add USER extensibility to an existing component:
 
 ```typescript
 // From SecurityValidator.hook.ts
-const USER_PATTERNS_PATH = paiPath('PAI', 'USER', 'PAISECURITYSYSTEM', 'patterns.yaml');
-const SYSTEM_PATTERNS_PATH = paiPath('PAI', 'PAISECURITYSYSTEM', 'patterns.example.yaml');
+const USER_PATTERNS_PATH = codePath('PAI', 'USER', 'PAISECURITYSYSTEM', 'patterns.yaml');
+const SYSTEM_PATTERNS_PATH = codePath('PAI', 'PAISECURITYSYSTEM', 'patterns.example.yaml');
 
 function getPatternsPath(): string | null {
   // USER first

--- a/Releases/v4.0.3+/.claude/hooks/KittyEnvPersist.hook.ts
+++ b/Releases/v4.0.3+/.claude/hooks/KittyEnvPersist.hook.ts
@@ -12,11 +12,9 @@
 
 import { writeFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
-import { getConfigDir } from './lib/paths';
+import { codePath } from './lib/paths';
 import { setTabState, readTabState } from './lib/tab-setter';
 import { getDAName } from './lib/identity';
-
-const configDir = getConfigDir();
 
 // Skip for subagents
 const claudeProjectDir = process.env.CLAUDE_PROJECT_DIR || '';
@@ -28,7 +26,7 @@ if (isSubagent) process.exit(0);
 const kittyListenOn = process.env.KITTY_LISTEN_ON;
 const kittyWindowId = process.env.KITTY_WINDOW_ID;
 if (kittyListenOn && kittyWindowId) {
-  const stateDir = join(configDir, 'MEMORY', 'STATE');
+  const stateDir = codePath('MEMORY', 'STATE');
   if (!existsSync(stateDir)) mkdirSync(stateDir, { recursive: true });
   writeFileSync(
     join(stateDir, 'kitty-env.json'),

--- a/Releases/v4.0.3+/.claude/hooks/LastResponseCache.hook.ts
+++ b/Releases/v4.0.3+/.claude/hooks/LastResponseCache.hook.ts
@@ -12,9 +12,8 @@
  */
 
 import { readHookInput, parseTranscriptFromInput } from './lib/hook-io';
-import { writeFileSync } from 'fs';
-import { join } from 'path';
-import { homedir } from 'os';
+import { writeFileSync, mkdirSync } from 'fs';
+import { codePath } from './lib/paths';
 
 async function main() {
   const input = await readHookInput();
@@ -29,8 +28,8 @@ async function main() {
 
   if (lastResponse) {
     try {
-      const paiDir = process.env.PAI_DIR || join(homedir(), '.claude');
-      const cachePath = join(paiDir, 'MEMORY', 'STATE', 'last-response.txt');
+      const cachePath = codePath('MEMORY', 'STATE', 'last-response.txt');
+      mkdirSync(codePath('MEMORY', 'STATE'), { recursive: true });
       writeFileSync(cachePath, lastResponse.slice(0, 2000), 'utf-8');
     } catch (err) {
       console.error('[LastResponseCache] Failed to write:', err);

--- a/Releases/v4.0.3+/.claude/hooks/LoadContext.hook.ts
+++ b/Releases/v4.0.3+/.claude/hooks/LoadContext.hook.ts
@@ -34,7 +34,7 @@
 
 import { readFileSync, existsSync, readdirSync } from 'fs';
 import { join } from 'path';
-import { getConfigDir, getPaiDir } from './lib/paths';
+import { getConfigDir, codePath } from './lib/paths';
 import { recordSessionStart } from './lib/notifications';
 import { loadLearningDigest, loadWisdomFrames, loadFailurePatterns, loadSignalTrends } from './lib/learning-readback';
 
@@ -67,9 +67,10 @@ function isDynamicEnabled(settings: Settings, key: keyof DynamicContextConfig): 
 
 /**
  * Load settings.json and return the settings object.
+ * settings.json lives in CONFIG root, not PAI root.
  */
-function loadSettings(paiDir: string): Settings {
-  const settingsPath = join(paiDir, 'settings.json');
+function loadSettings(configDir: string): Settings {
+  const settingsPath = join(configDir, 'settings.json');
   if (existsSync(settingsPath)) {
     try {
       return JSON.parse(readFileSync(settingsPath, 'utf-8'));
@@ -84,13 +85,13 @@ function loadSettings(paiDir: string): Settings {
  * Load files listed in settings.json → loadAtStartup.files
  * Reads each file and injects as a system-reminder block.
  */
-function loadStartupFiles(paiDir: string, settings: Settings): string | null {
+function loadStartupFiles(settings: Settings): string | null {
   const config = settings.loadAtStartup;
   if (!config?.files || config.files.length === 0) return null;
 
   const parts: string[] = [];
   for (const relPath of config.files) {
-    const fullPath = join(paiDir, relPath);
+    const fullPath = codePath(relPath);
     if (!existsSync(fullPath)) {
       console.error(`⚠️ loadAtStartup: file not found: ${relPath}`);
       continue;
@@ -112,11 +113,11 @@ function loadStartupFiles(paiDir: string, settings: Settings): string | null {
  * Load relationship context for session startup.
  * Returns a lightweight summary of key opinions and recent notes.
  */
-function loadRelationshipContext(configDir: string, paiDir: string): string | null {
+function loadRelationshipContext(): string | null {
   const parts: string[] = [];
 
   // Load high-confidence opinions (>0.85) from OPINIONS.md (PAI code root)
-  const opinionsPath = join(paiDir, 'PAI/USER/OPINIONS.md');
+  const opinionsPath = codePath('PAI', 'USER', 'OPINIONS.md');
   if (existsSync(opinionsPath)) {
     try {
       const content = readFileSync(opinionsPath, 'utf-8');
@@ -153,9 +154,9 @@ function loadRelationshipContext(configDir: string, paiDir: string): string | nu
 
   const recentNotes: string[] = [];
   for (const date of [today, yesterday]) {
-    const notePath = join(
-      configDir,
-      'MEMORY/RELATIONSHIP',
+    const notePath = codePath(
+      'MEMORY',
+      'RELATIONSHIP',
       formatMonth(date),
       `${formatDate(date)}.md`
     );
@@ -207,12 +208,12 @@ interface WorkSession {
 /**
  * Scan recent WORK/ directories (last 48h) for active sessions.
  */
-function getRecentWorkSessions(paiDir: string): WorkSession[] {
-  const workDir = join(paiDir, 'MEMORY', 'WORK');
+function getRecentWorkSessions(): WorkSession[] {
+  const workDir = codePath('MEMORY', 'WORK');
   if (!existsSync(workDir)) return [];
 
   let sessionNames: Record<string, string> = {};
-  const namesPath = join(paiDir, 'MEMORY', 'STATE', 'session-names.json');
+  const namesPath = codePath('MEMORY', 'STATE', 'session-names.json');
   try {
     if (existsSync(namesPath)) {
       sessionNames = JSON.parse(readFileSync(namesPath, 'utf-8'));
@@ -331,8 +332,8 @@ function getRecentWorkSessions(paiDir: string): WorkSession[] {
 /**
  * Load persistent project progress files, flagging stale ones (>14 days).
  */
-function getProjectProgress(paiDir: string): WorkSession[] {
-  const progressDir = join(paiDir, 'MEMORY', 'STATE', 'progress');
+function getProjectProgress(): WorkSession[] {
+  const progressDir = codePath('MEMORY', 'STATE', 'progress');
   if (!existsSync(progressDir)) return [];
 
   const sessions: WorkSession[] = [];
@@ -384,9 +385,9 @@ function getProjectProgress(paiDir: string): WorkSession[] {
 /**
  * Unified activity dashboard — merges recent WORK sessions + persistent projects.
  */
-async function checkActiveProgress(paiDir: string): Promise<string | null> {
-  const recentSessions = getRecentWorkSessions(paiDir);
-  const projects = getProjectProgress(paiDir);
+async function checkActiveProgress(): Promise<string | null> {
+  const recentSessions = getRecentWorkSessions();
+  const projects = getProjectProgress();
 
   if (recentSessions.length === 0 && projects.length === 0) {
     return null;
@@ -427,9 +428,9 @@ async function checkActiveProgress(paiDir: string): Promise<string | null> {
     }
   }
 
-  const pDir = getPaiDir();
-  summary += `\n💡 To resume project: \`bun run ${pDir}/PAI/Tools/SessionProgress.ts resume <project>\`\n`;
-  summary += `💡 To complete project: \`bun run ${pDir}/PAI/Tools/SessionProgress.ts complete <project>\`\n`;
+  const sessionProgressPath = codePath('PAI', 'Tools', 'SessionProgress.ts');
+  summary += `\n💡 To resume project: \`bun run ${sessionProgressPath} resume <project>\`\n`;
+  summary += `💡 To complete project: \`bun run ${sessionProgressPath} complete <project>\`\n`;
 
   return summary;
 }
@@ -447,7 +448,6 @@ async function main() {
     }
 
     const configDir = getConfigDir();
-    const paiDir = getPaiDir();
 
     // Tab reset is handled by KittyEnvPersist.hook.ts (runs before this hook)
 
@@ -460,7 +460,7 @@ async function main() {
     console.error('✅ Loaded settings.json');
 
     // Force-load startup files from settings.json → loadAtStartup (paths relative to PAI code root)
-    const startupContent = loadStartupFiles(paiDir, settings);
+    const startupContent = loadStartupFiles(settings);
     if (startupContent) {
       console.log(`<system-reminder>\n${startupContent}\n</system-reminder>`);
     }
@@ -468,7 +468,7 @@ async function main() {
     // Load relationship context (lightweight summary)
     let relationshipContext: string | null = null;
     if (isDynamicEnabled(settings, 'relationshipContext')) {
-      relationshipContext = loadRelationshipContext(configDir, paiDir);
+      relationshipContext = loadRelationshipContext();
       if (relationshipContext) {
         console.error(`💕 Loaded relationship context (${relationshipContext.length} chars)`);
       }
@@ -479,10 +479,10 @@ async function main() {
     // Load learning readback context
     let learningContext = '';
     if (isDynamicEnabled(settings, 'learningReadback')) {
-      const learningDigest = loadLearningDigest(configDir);
-      const wisdomFrames = loadWisdomFrames(configDir);
-      const failurePatterns = loadFailurePatterns(configDir);
-      const signalTrends = loadSignalTrends(configDir);
+      const learningDigest = loadLearningDigest();
+      const wisdomFrames = loadWisdomFrames();
+      const failurePatterns = loadFailurePatterns();
+      const signalTrends = loadSignalTrends();
 
       const learningParts: string[] = [];
       if (signalTrends) learningParts.push(signalTrends);
@@ -518,7 +518,7 @@ Dynamic context loaded. Core identity, rules, and format are in CLAUDE.md.
 
     // Active work summary
     if (isDynamicEnabled(settings, 'activeWorkSummary')) {
-      const activeProgress = await checkActiveProgress(configDir);
+      const activeProgress = await checkActiveProgress();
       if (activeProgress) {
         console.log(activeProgress);
         console.error(`📋 Active work summary loaded (${activeProgress.length} chars)`);

--- a/Releases/v4.0.3+/.claude/hooks/RelationshipMemory.hook.ts
+++ b/Releases/v4.0.3+/.claude/hooks/RelationshipMemory.hook.ts
@@ -265,9 +265,8 @@ async function main() {
       process.exit(0);
     }
 
-    // Write to daily relationship file
-    const configDir = getConfigDir();
-    const filepath = ensureRelationshipDir(configDir);
+    // Write to daily relationship file (RELATIONSHIP lives under PAI root)
+    const filepath = ensureRelationshipDir(getPaiDir());
     initDailyFile(filepath);
 
     const formatted = formatNotes(notes);

--- a/Releases/v4.0.3+/.claude/hooks/SessionCleanup.hook.ts
+++ b/Releases/v4.0.3+/.claude/hooks/SessionCleanup.hook.ts
@@ -38,11 +38,10 @@ import { writeFileSync, existsSync, readFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { getISOTimestamp } from './lib/time';
 import { setTabState, cleanupKittySession } from './lib/tab-setter';
+import { codePath } from './lib/paths';
 
-const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
-const MEMORY_DIR = join(BASE_DIR, 'MEMORY');
-const STATE_DIR = join(MEMORY_DIR, 'STATE');
-const WORK_DIR = join(MEMORY_DIR, 'WORK');
+const STATE_DIR = codePath('MEMORY', 'STATE');
+const WORK_DIR = codePath('MEMORY', 'WORK');
 
 // Session-scoped state file lookup with legacy fallback
 function findStateFile(sessionId?: string): string | null {

--- a/Releases/v4.0.3+/.claude/hooks/VoiceCompletion.hook.ts
+++ b/Releases/v4.0.3+/.claude/hooks/VoiceCompletion.hook.ts
@@ -17,10 +17,9 @@
  */
 
 import { readFileSync, existsSync } from 'fs';
-import { join } from 'path';
-import { homedir } from 'os';
 import { readHookInput, parseTranscriptFromInput } from './lib/hook-io';
 import { handleVoice } from './handlers/VoiceNotification';
+import { getSettingsPath } from './lib/paths';
 
 /**
  * Voice gate: only main terminal sessions get voice.
@@ -39,7 +38,7 @@ function isMainSession(): boolean {
  */
 function isVoiceEnabled(): boolean {
   try {
-    const settingsPath = join(homedir(), '.claude', 'settings.json');
+    const settingsPath = getSettingsPath();
     if (!existsSync(settingsPath)) return true;
     const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
     return settings.notifications?.voice?.enabled !== false;

--- a/Releases/v4.0.3+/.claude/hooks/WorkCompletionLearning.hook.ts
+++ b/Releases/v4.0.3+/.claude/hooks/WorkCompletionLearning.hook.ts
@@ -54,12 +54,11 @@ import { writeFileSync, existsSync, readFileSync, readdirSync, mkdirSync } from 
 import { join, dirname } from 'path';
 import { getISOTimestamp, getPSTDate } from './lib/time';
 import { getLearningCategory } from './lib/learning-utils';
+import { codePath } from './lib/paths';
 
-const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
-const MEMORY_DIR = join(BASE_DIR, 'MEMORY');
-const STATE_DIR = join(MEMORY_DIR, 'STATE');
-const WORK_DIR = join(MEMORY_DIR, 'WORK');
-const LEARNING_DIR = join(MEMORY_DIR, 'LEARNING');
+const STATE_DIR = codePath('MEMORY', 'STATE');
+const WORK_DIR = codePath('MEMORY', 'WORK');
+const LEARNING_DIR = codePath('MEMORY', 'LEARNING');
 
 // Session-scoped state file lookup with legacy fallback
 function findStateFile(sessionId?: string): string | null {

--- a/Releases/v4.0.3+/.claude/hooks/handlers/DocCrossRefIntegrity.ts
+++ b/Releases/v4.0.3+/.claude/hooks/handlers/DocCrossRefIntegrity.ts
@@ -71,7 +71,7 @@ interface DriftReport {
 // ============================================================================
 
 const SYSTEM_DIR = codePath('PAI');
-const HOOKS_DIR = configPath('hooks');
+const HOOKS_DIR = codePath('hooks');
 const HANDLERS_DIR = join(HOOKS_DIR, 'handlers');
 const LIB_DIR = join(HOOKS_DIR, 'lib');
 const DRIFT_STATE_FILE = codePath('MEMORY', 'STATE', 'doc-drift-state.json');

--- a/Releases/v4.0.3+/.claude/hooks/handlers/UpdateCounts.ts
+++ b/Releases/v4.0.3+/.claude/hooks/handlers/UpdateCounts.ts
@@ -19,7 +19,7 @@
 import { readFileSync, writeFileSync, readdirSync, existsSync, statSync } from 'fs';
 import { join } from 'path';
 import { execSync, spawn } from 'child_process';
-import { getConfigDir, getPaiDir, getSettingsPath } from '../lib/paths';
+import { getConfigDir, getPaiDir, getSettingsPath, codePath } from '../lib/paths';
 
 
 interface Counts {
@@ -148,17 +148,17 @@ function countSubdirs(dir: string): number {
  * Get all counts
  */
 function getCounts(configDir: string, paiDir: string): Counts {
-  const ratingsPath = join(configDir, 'MEMORY/LEARNING/SIGNALS/ratings.jsonl');
+  const ratingsPath = codePath('MEMORY', 'LEARNING', 'SIGNALS', 'ratings.jsonl');
   return {
     skills: countSkills(paiDir),
     workflows: countWorkflowFiles(join(paiDir, 'skills')),
-    hooks: countHooks(configDir),
-    signals: countFilesRecursive(join(configDir, 'MEMORY/LEARNING'), '.md'),
+    hooks: countHooks(paiDir),
+    signals: countFilesRecursive(codePath('MEMORY', 'LEARNING'), '.md'),
     files: countFilesRecursive(join(paiDir, 'PAI/USER')),
-    work: countSubdirs(join(configDir, 'MEMORY/WORK')),
-    sessions: countFilesRecursive(join(configDir, 'MEMORY'), '.jsonl'),
-    research: countFilesRecursive(join(configDir, 'MEMORY/RESEARCH'), '.md') +
-              countFilesRecursive(join(configDir, 'MEMORY/RESEARCH'), '.json'),
+    work: countSubdirs(codePath('MEMORY', 'WORK')),
+    sessions: countFilesRecursive(codePath('MEMORY'), '.jsonl'),
+    research: countFilesRecursive(codePath('MEMORY', 'RESEARCH'), '.md') +
+              countFilesRecursive(codePath('MEMORY', 'RESEARCH'), '.json'),
     ratings: countRatingsLines(ratingsPath),
     updatedAt: new Date().toISOString(),
   };
@@ -168,8 +168,8 @@ function getCounts(configDir: string, paiDir: string): Counts {
  * Refresh usage cache from Anthropic OAuth API.
  * Called by stop hook so status line never needs to make this 700ms API call.
  */
-async function refreshUsageCache(paiDir: string): Promise<void> {
-  const usageCachePath = join(paiDir, 'MEMORY/STATE/usage-cache.json');
+async function refreshUsageCache(): Promise<void> {
+  const usageCachePath = codePath('MEMORY', 'STATE', 'usage-cache.json');
 
   try {
     // Extract OAuth token — macOS Keychain or Linux credentials file
@@ -281,7 +281,7 @@ export async function handleUpdateCounts(): Promise<void> {
     // signal aborting it ("Hook cancelled"). A detached process runs independently
     // and isn't killed when the hook exits.
     try {
-      const scriptPath = join(configDir, 'hooks', 'handlers', 'UpdateCounts.ts');
+      const scriptPath = join(paiDir, 'hooks', 'handlers', 'UpdateCounts.ts');
       const child = spawn('bun', ['run', scriptPath], {
         detached: true,
         stdio: 'ignore',
@@ -302,7 +302,7 @@ export async function handleUpdateCounts(): Promise<void> {
 // - UPDATE_COUNTS_REFRESH_ONLY=1: only refresh usage cache — spawned as detached bg process by the hook
 if (import.meta.main) {
   if (process.env.UPDATE_COUNTS_REFRESH_ONLY === '1') {
-    refreshUsageCache(getConfigDir()).then(() => process.exit(0)).catch(() => process.exit(0));
+    refreshUsageCache().then(() => process.exit(0)).catch(() => process.exit(0));
   } else {
     handleUpdateCounts().then(() => process.exit(0));
   }

--- a/Releases/v4.0.3+/.claude/hooks/handlers/VoiceNotification.ts
+++ b/Releases/v4.0.3+/.claude/hooks/handlers/VoiceNotification.ts
@@ -11,7 +11,7 @@
 
 import { existsSync, readFileSync, appendFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
-import { configPath, codePath } from '../lib/paths';
+import { codePath } from '../lib/paths';
 import { getIdentity, type VoicePersonality } from '../lib/identity';
 import { getISOTimestamp } from '../lib/time';
 import { isValidVoiceCompletion, getVoiceFallback } from '../lib/output-validators';

--- a/Releases/v4.0.3+/.claude/hooks/lib/change-detection.ts
+++ b/Releases/v4.0.3+/.claude/hooks/lib/change-detection.ts
@@ -7,7 +7,7 @@
 
 import { readFileSync, existsSync } from 'fs';
 import { join, relative, basename } from 'path';
-import { getConfigDir, getPaiDir } from './paths';
+import { getPaiDir } from './paths';
 
 // ============================================================================
 // Types
@@ -52,9 +52,8 @@ export interface IntegrityState {
 // Path Constants
 // ============================================================================
 
-const CONFIG_DIR = getConfigDir();
 const PAI_DIR = getPaiDir();
-const STATE_FILE = join(CONFIG_DIR, 'MEMORY', 'STATE', 'integrity-state.json');
+const STATE_FILE = join(PAI_DIR, 'MEMORY', 'STATE', 'integrity-state.json');
 
 // Paths that are excluded from integrity checks
 const EXCLUDED_PATHS = [

--- a/Releases/v4.0.3+/.claude/hooks/lib/identity.ts
+++ b/Releases/v4.0.3+/.claude/hooks/lib/identity.ts
@@ -7,10 +7,9 @@
  */
 
 import { readFileSync, existsSync } from 'fs';
-import { join } from 'path';
+import { getSettingsPath } from './paths';
 
-const HOME = process.env.HOME!;
-const SETTINGS_PATH = join(HOME, '.claude/settings.json');
+const SETTINGS_PATH = getSettingsPath();
 
 // Default identity (fallback if settings.json doesn't have identity section)
 const DEFAULT_IDENTITY = {

--- a/Releases/v4.0.3+/.claude/hooks/lib/notifications.ts
+++ b/Releases/v4.0.3+/.claude/hooks/lib/notifications.ts
@@ -6,8 +6,7 @@
  */
 
 import { readFileSync, writeFileSync, existsSync } from 'fs';
-import { join } from 'path';
-import { homedir } from 'os';
+import { getSettingsPath } from './paths';
 
 // ============================================================================
 // Session Timing
@@ -43,8 +42,7 @@ export interface NotificationOptions {
 
 function loadNtfyConfig(): { enabled: boolean; topic: string; server: string } {
   try {
-    const paiDir = process.env.PAI_DIR || join(homedir(), '.claude');
-    const settingsPath = join(paiDir, 'settings.json');
+    const settingsPath = getSettingsPath();
     if (!existsSync(settingsPath)) return { enabled: false, topic: '', server: 'ntfy.sh' };
 
     const raw = readFileSync(settingsPath, 'utf-8')

--- a/Releases/v4.0.3+/.claude/hooks/lib/paths.ts
+++ b/Releases/v4.0.3+/.claude/hooks/lib/paths.ts
@@ -2,8 +2,8 @@
  * Centralized Path Resolution
  *
  * Two-root architecture:
- *   - CONFIG root (CLAUDE_CONFIG_DIR): CC config — hooks, MEMORY, settings.json, projects
- *   - PAI root (PAI_DIR): PAI code — PAI/Tools, Algorithm, skills, agents
+ *   - CONFIG root (CLAUDE_CONFIG_DIR): Claude Code config — CC's own settings.json, sessions, projects
+ *   - PAI root (PAI_DIR): PAI install — hooks, PAI/Tools, Algorithm, skills, agents, VoiceServer, MEMORY, USER
  *
  * Usage:
  *   import { getConfigDir, getPaiDir, configPath, codePath } from './lib/paths';
@@ -70,13 +70,6 @@ export function codePath(...segments: string[]): string {
 }
 
 /**
- * Get a path relative to PAI_DIR (backward compat alias for codePath)
- */
-export function paiPath(...segments: string[]): string {
-  return join(getPaiDir(), ...segments);
-}
-
-/**
  * Get the settings.json path (lives in CONFIG root)
  */
 export function getSettingsPath(): string {
@@ -84,10 +77,10 @@ export function getSettingsPath(): string {
 }
 
 /**
- * Get the hooks directory (lives in CONFIG root)
+ * Get the hooks directory (lives in PAI root — PAI's hooks are part of the PAI install)
  */
 export function getHooksDir(): string {
-  return configPath('hooks');
+  return codePath('hooks');
 }
 
 /**

--- a/Releases/v4.0.3+/.claude/hooks/lib/prd-utils.ts
+++ b/Releases/v4.0.3+/.claude/hooks/lib/prd-utils.ts
@@ -11,7 +11,7 @@
 
 import { readFileSync, writeFileSync, readdirSync, statSync, existsSync, mkdirSync, renameSync } from 'fs';
 import { join } from 'path';
-import { configPath, codePath } from './paths';
+import { codePath } from './paths';
 
 export const WORK_DIR = codePath('MEMORY', 'WORK');
 export const WORK_JSON = codePath('MEMORY', 'STATE', 'work.json');
@@ -110,8 +110,8 @@ export function writeRegistry(reg: { sessions: Record<string, any> }): void {
 
 export function syncToWorkJson(fm: Record<string, string>, prdPath: string, content?: string, sessionId?: string): void {
   if (!fm.slug) return;
-  const cfgDir = configPath();
-  const relativePrd = prdPath.replace(cfgDir + '/', '');
+  const paiRoot = codePath();
+  const relativePrd = prdPath.replace(paiRoot + '/', '');
   const registry = readRegistry();
 
   // Migration: if there's a 'starting' or 'native' placeholder entry for this session UUID,

--- a/Releases/v4.0.3+/.claude/hooks/lib/tab-setter.ts
+++ b/Releases/v4.0.3+/.claude/hooks/lib/tab-setter.ts
@@ -12,7 +12,7 @@ import { existsSync, writeFileSync, mkdirSync, readdirSync, unlinkSync, readFile
 import { join } from 'path';
 import { execSync } from 'child_process';
 import { TAB_COLORS, PHASE_TAB_CONFIG, ACTIVE_TAB_BG, ACTIVE_TAB_FG, INACTIVE_TAB_FG, type TabState, type AlgorithmTabPhase } from './tab-constants';
-import { configPath, codePath } from './paths';
+import { codePath } from './paths';
 
 const TAB_TITLES_DIR = codePath('MEMORY', 'STATE', 'tab-titles');
 const KITTY_SESSIONS_DIR = codePath('MEMORY', 'STATE', 'kitty-sessions');

--- a/Releases/v4.0.3+/.claude/settings.json
+++ b/Releases/v4.0.3+/.claude/settings.json
@@ -72,7 +72,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_CONFIG_DIR}/hooks/SecurityValidator.hook.ts"
+            "command": "${PAI_DIR}/hooks/SecurityValidator.hook.ts"
           }
         ]
       },
@@ -81,7 +81,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_CONFIG_DIR}/hooks/SecurityValidator.hook.ts"
+            "command": "${PAI_DIR}/hooks/SecurityValidator.hook.ts"
           }
         ]
       },
@@ -90,7 +90,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_CONFIG_DIR}/hooks/SecurityValidator.hook.ts"
+            "command": "${PAI_DIR}/hooks/SecurityValidator.hook.ts"
           }
         ]
       },
@@ -99,7 +99,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_CONFIG_DIR}/hooks/SecurityValidator.hook.ts"
+            "command": "${PAI_DIR}/hooks/SecurityValidator.hook.ts"
           }
         ]
       },
@@ -108,7 +108,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_CONFIG_DIR}/hooks/SetQuestionTab.hook.ts"
+            "command": "${PAI_DIR}/hooks/SetQuestionTab.hook.ts"
           }
         ]
       },
@@ -117,7 +117,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_CONFIG_DIR}/hooks/AgentExecutionGuard.hook.ts"
+            "command": "${PAI_DIR}/hooks/AgentExecutionGuard.hook.ts"
           }
         ]
       },
@@ -126,7 +126,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_CONFIG_DIR}/hooks/SkillGuard.hook.ts"
+            "command": "${PAI_DIR}/hooks/SkillGuard.hook.ts"
           }
         ]
       }
@@ -137,7 +137,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_CONFIG_DIR}/hooks/QuestionAnswered.hook.ts"
+            "command": "${PAI_DIR}/hooks/QuestionAnswered.hook.ts"
           }
         ]
       },
@@ -146,7 +146,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_CONFIG_DIR}/hooks/PRDSync.hook.ts"
+            "command": "${PAI_DIR}/hooks/PRDSync.hook.ts"
           }
         ]
       },
@@ -155,7 +155,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_CONFIG_DIR}/hooks/PRDSync.hook.ts"
+            "command": "${PAI_DIR}/hooks/PRDSync.hook.ts"
           }
         ]
       }
@@ -165,23 +165,23 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_CONFIG_DIR}/hooks/WorkCompletionLearning.hook.ts"
+            "command": "${PAI_DIR}/hooks/WorkCompletionLearning.hook.ts"
           },
           {
             "type": "command",
-            "command": "${CLAUDE_CONFIG_DIR}/hooks/SessionCleanup.hook.ts"
+            "command": "${PAI_DIR}/hooks/SessionCleanup.hook.ts"
           },
           {
             "type": "command",
-            "command": "${CLAUDE_CONFIG_DIR}/hooks/RelationshipMemory.hook.ts"
+            "command": "${PAI_DIR}/hooks/RelationshipMemory.hook.ts"
           },
           {
             "type": "command",
-            "command": "${CLAUDE_CONFIG_DIR}/hooks/UpdateCounts.hook.ts"
+            "command": "${PAI_DIR}/hooks/UpdateCounts.hook.ts"
           },
           {
             "type": "command",
-            "command": "${CLAUDE_CONFIG_DIR}/hooks/IntegrityCheck.hook.ts"
+            "command": "${PAI_DIR}/hooks/IntegrityCheck.hook.ts"
           }
         ]
       }
@@ -191,15 +191,15 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_CONFIG_DIR}/hooks/RatingCapture.hook.ts"
+            "command": "${PAI_DIR}/hooks/RatingCapture.hook.ts"
           },
           {
             "type": "command",
-            "command": "${CLAUDE_CONFIG_DIR}/hooks/UpdateTabTitle.hook.ts"
+            "command": "${PAI_DIR}/hooks/UpdateTabTitle.hook.ts"
           },
           {
             "type": "command",
-            "command": "${CLAUDE_CONFIG_DIR}/hooks/SessionAutoName.hook.ts"
+            "command": "${PAI_DIR}/hooks/SessionAutoName.hook.ts"
           }
         ]
       }
@@ -209,15 +209,15 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_CONFIG_DIR}/hooks/KittyEnvPersist.hook.ts"
+            "command": "${PAI_DIR}/hooks/KittyEnvPersist.hook.ts"
           },
           {
             "type": "command",
-            "command": "${CLAUDE_CONFIG_DIR}/hooks/LoadContext.hook.ts"
+            "command": "${PAI_DIR}/hooks/LoadContext.hook.ts"
           },
           {
             "type": "command",
-            "command": "bun ${CLAUDE_CONFIG_DIR}/hooks/handlers/BuildCLAUDE.ts"
+            "command": "bun ${PAI_DIR}/hooks/handlers/BuildCLAUDE.ts"
           }
         ]
       }
@@ -227,19 +227,19 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_CONFIG_DIR}/hooks/LastResponseCache.hook.ts"
+            "command": "${PAI_DIR}/hooks/LastResponseCache.hook.ts"
           },
           {
             "type": "command",
-            "command": "${CLAUDE_CONFIG_DIR}/hooks/ResponseTabReset.hook.ts"
+            "command": "${PAI_DIR}/hooks/ResponseTabReset.hook.ts"
           },
           {
             "type": "command",
-            "command": "${CLAUDE_CONFIG_DIR}/hooks/VoiceCompletion.hook.ts"
+            "command": "${PAI_DIR}/hooks/VoiceCompletion.hook.ts"
           },
           {
             "type": "command",
-            "command": "${CLAUDE_CONFIG_DIR}/hooks/DocIntegrity.hook.ts"
+            "command": "${PAI_DIR}/hooks/DocIntegrity.hook.ts"
           }
         ]
       }
@@ -998,7 +998,7 @@
     },
     "_migration": "Identity configuration moved from DAIDENTITY.md to settings.json. The daidentity and principal sections replace the old env.DA and env.PRINCIPAL patterns. All hooks now read from settings.json via the centralized identity module (hooks/lib/identity.ts).",
     "_env": {
-      "CLAUDE_CONFIG_DIR": "CC config root (~/.claude). Hooks, MEMORY, settings.json, projects live here.",
+      "CLAUDE_CONFIG_DIR": "Claude Code config root (~/.claude). Claude Code's own settings.json, sessions, projects live here. PAI hooks, code, skills, agents, MEMORY, USER all live under PAI_DIR.",
       "PAI_DIR": "Root directory for PAI code installation (~/.pai). Skills, agents, tools, algorithm live here.",
       "PROJECTS_DIR": "Base directory for projects. Use ${PROJECTS_DIR}/PAI for PAI repo, ${PROJECTS_DIR}/fabric for fabric, etc.",
       "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "Maximum tokens for Claude responses. Higher values allow longer outputs but cost more.",

--- a/Releases/v4.0.3+/README.md
+++ b/Releases/v4.0.3+/README.md
@@ -23,6 +23,27 @@ This is the active development release — all personal improvements and customi
 
 ## What Changed (from upstream v4.0.3)
 
+### Breaking Changes
+
+#### `CLAUDE_CONFIG_DIR` + `PAI_DIR` two-root split
+
+Prior releases conflated Claude Code's own config with the PAI installation under a single `~/.claude/` root. v4.0.3+ splits them in two:
+
+| Root | Env var | Contents |
+|------|---------|----------|
+| `~/.claude/` | `CLAUDE_CONFIG_DIR` | Claude Code's own config: `settings.json`, `sessions/`, `projects/`, CC's `CLAUDE.md` |
+| `~/.pai/` | `PAI_DIR` | PAI installation: `hooks/`, `PAI/`, `skills/`, `agents/`, `VoiceServer/`, `MEMORY/`, `USER/` |
+
+Hook files, skills, agents, and — importantly — `MEMORY/` now live under `~/.pai/`. The `paths.ts` helper module exposes `getConfigDir()`, `getPaiDir()`, `configPath()`, and `codePath()` for programmatic resolution of either root. Both env vars fall back to sensible defaults if unset.
+
+**Required manual migration for v4.0.2 upgraders:** if you have an existing `~/.claude/MEMORY/` directory from a prior release, you must move it to `~/.pai/MEMORY/` **before** running v4.0.3+ for the first time. The installer does not automate this yet (see the open issue on `virtualian/pai` for the migration automator follow-up). Failing to migrate causes the first post-upgrade session to boot with no correction history, no behavioral signals, and no synthesis — and any new writes will land in `~/.pai/MEMORY/`, orphaning the old data.
+
+```bash
+# Before your first v4.0.3+ session:
+mkdir -p ~/.pai
+mv ~/.claude/MEMORY ~/.pai/MEMORY
+```
+
 ### Upstream Fixes (inherited from v4.0.3)
 
 Community-contributed fixes from open PRs — no new features, no breaking changes.
@@ -76,15 +97,22 @@ cp -r .claude ~/ && cd ~/.claude && bash install.sh
 # 1. Back up
 cp -r ~/.claude ~/.claude-backup-$(date +%Y%m%d)
 
-# 2. Clone and copy
+# 2. Migrate MEMORY to the new PAI root (REQUIRED for v4.0.2 upgraders)
+#    Skip this step only if ~/.claude/MEMORY/ does not exist.
+if [ -d ~/.claude/MEMORY ]; then
+  mkdir -p ~/.pai
+  mv ~/.claude/MEMORY ~/.pai/MEMORY
+fi
+
+# 3. Clone and copy
 git clone https://github.com/danielmiessler/Personal_AI_Infrastructure.git
 cd Personal_AI_Infrastructure/Releases/v4.0.3
 cp -r .claude ~/
 
-# 3. Run the installer
+# 4. Run the installer
 cd ~/.claude && bash install.sh
 
-# 4. Rebuild CLAUDE.md
+# 5. Rebuild CLAUDE.md
 bun ~/.pai/PAI/Tools/BuildCLAUDE.ts
 ```
 


### PR DESCRIPTION
## Summary

Focused refactor completing the `CLAUDE_CONFIG_DIR` + `PAI_DIR` two-root separation. This PR **supersedes #103** and is intentionally narrow: 20 files, +136/-128, all in the hooks layer plus the release README and one SYSTEM doc.

## Background — why this replaces #103

Issue #100's two-root split landed on `main` in two pieces:

1. **PR #101** squash-merged 4 commits from branch `100-claude-config-dir-pai-dir-separation`. That squash silently bundled `ebc8130`, which **also** deleted ~606 lines of unrelated functionality: `CorrectionMode` fast-path, `BehavioralSignal` capture, and `loadLatestSynthesis`. No one noticed during review because the deletions were hidden inside a 400-file "refactor" commit.
2. **PR #104** (the hotfix) restored those 606 lines as a narrow 2-file PR.
3. **PR #105** added a CI symbol-presence guard to make silent deletions of those subsystems impossible in future PRs.

After #101, #104, and #105, PR #103's *semantic* delta collapsed from 403 files / +1712/-1658 (merge-base relative) to the 18-file correction set that genuinely differs from post-hotfix main. GitHub's PR UI couldn't show this because the merge base hadn't moved. #103 is also `CONFLICTING` — a naive rebase produces phantom conflicts because git's patch-ID matching cannot resolve the `ebc8130` hunks against #101's squash.

This PR is the rebased outcome, produced via file-copy reconstruction + the 3 cleanup decisions documented below.

## What this PR does

### 1. Path-separation fixes (18 files from #103's correction commits)

All of these are corrections to bugs introduced or left behind by `ebc8130`:

- `settings.json` — revert 13 hook command paths from `${CLAUDE_CONFIG_DIR}/hooks/*` back to `${PAI_DIR}/hooks/*`. Hooks physically live under `PAI_DIR` after the split.
- `paths.ts` — `getHooksDir()` now returns `codePath('hooks')` (not `configPath('hooks')`). Docstring rewrites for the two-root contract.
- `LoadContext.hook.ts` — eliminate the `paiDir` parameter chain across 5 helpers. 5 raw `join(paiDir, ...)` calls routed through `codePath()`. Rename misleading `loadSettings` parameter. Extract `sessionProgressPath`.
- `UpdateCounts.ts` — `countHooks` and `refreshUsageCache` now read MEMORY from the PAI root. After #101's MEMORY move, the CONFIG-root reads silently returned empty data.
- `RelationshipMemory.hook.ts` — `ensureRelationshipDir` fixed for the split.
- `LastResponseCache.hook.ts` — `mkdirSync` before `writeFileSync` (silent `ENOENT` on fresh install).
- `prd-utils.ts` — correct `.replace()` prefix from `configPath` to `codePath`.
- `VoiceCompletion.hook.ts` — replace hardcoded `~/.claude/settings.json` with `getSettingsPath()`.
- `VoiceNotification.ts`, `tab-setter.ts` — drop dead `configPath` imports.
- `DocCrossRefIntegrity.ts`, `change-detection.ts`, `identity.ts`, `notifications.ts`, `SessionCleanup.hook.ts`, `KittyEnvPersist.hook.ts`, `WorkCompletionLearning.hook.ts` — small `codePath` / `configPath` cleanups.
- `.pai-protected.json` — correct stale comment.

### 2. Delete `paiPath()` alias outright

`paths.ts` previously kept `paiPath()` as a deprecated alias for `codePath()` to preserve backward compatibility. This PR removes it entirely.

**Rationale.** The semantic flip in v4.0.3 (pre-split `paiPath(x)` → `~/.claude/x`, post-split `paiPath(x)` → `~/.pai/x`) is exactly the class of change where a silent alias is a landmine, not a safety net. A caller that survives the grep would silently write to a different directory, and the failure mode is "files appear in an unexpected location" — one of the worst bugs to diagnose. Deleting the function forces the compiler to catch any revenant caller. Zero code callers existed when this commit was written.

`SYSTEM_USER_EXTENDABILITY.md` had 4 documentation examples using `paiPath()` — those are updated to `codePath()` in the same commit so the documentation matches the public API.

### 3. MEMORY migration release note

`Releases/v4.0.3+/README.md` gains a "Breaking Changes" subsection explaining the two-root split and — crucially — a required manual migration step for v4.0.2 upgraders:

```bash
if [ -d ~/.claude/MEMORY ]; then
  mkdir -p ~/.pai
  mv ~/.claude/MEMORY ~/.pai/MEMORY
fi
```

This is a deliberate decision to ship the migration as **documentation + manual command** rather than as automated installer logic. Reasoning:

- The current user base is solo (myself) plus whoever forks from here. A release-note + explicit command is sufficient coverage without adding installer complexity under time pressure.
- An automated migrator belongs in a focused follow-up PR that can be reviewed on its own merits (idempotency, error handling, rollback semantics) rather than bundled inside a refactor.
- I will open a tracking issue immediately after this PR for the automator work.

## What this PR does *not* do (deliberately deferred)

- **`statusLine.command`** still points at `${CLAUDE_CONFIG_DIR}/statusline-command.sh`. The physical script lives at `~/.claude/statusline-command.sh`. Relocating it under `PAI_DIR` is a one-file move + one settings line + one installer template update — a valid change, but it doesn't belong inside this refactor because it's a separate decision about which root owns the statusline script. **Tracked as a follow-up.**
- **Automated MEMORY migrator** — see above, covered by a follow-up issue.

## Verification

Run against this commit locally before pushing:

- ✅ `bun build --target=bun` clean on all 17 touched hook TypeScript files (`paths.ts`, `prd-utils.ts`, `LoadContext.hook.ts`, `LastResponseCache.hook.ts`, `VoiceCompletion.hook.ts`, `RelationshipMemory.hook.ts`, `WorkCompletionLearning.hook.ts`, `KittyEnvPersist.hook.ts`, `SessionCleanup.hook.ts`, `learning-readback.ts`, `tab-setter.ts`, `change-detection.ts`, `identity.ts`, `notifications.ts`, `UpdateCounts.ts`, `VoiceNotification.ts`, `DocCrossRefIntegrity.ts`)
- ✅ `settings.json` parses as valid JSON
- ✅ Env-var resolution test (`CLAUDE_CONFIG_DIR=/tmp/ctest PAI_DIR=/tmp/ptest`): **10/10 assertions pass** — `getConfigDir()`, `getPaiDir()`, `configPath('hooks')`, `codePath('MEMORY')`, `codePath('PAI','Tools')`, `getSettingsPath()`, `getHooksDir()`, `getMemoryDir()`, `getSkillsDir()` all resolve to the expected roots
- ✅ `settings.json` hook-command audit: **0** references to `${CLAUDE_CONFIG_DIR}/hooks`, **24** references to `${PAI_DIR}/hooks`
- ✅ MEMORY routing audit: **0** `configPath('MEMORY'`, **45** `codePath('MEMORY'`, **0** raw `~/.claude/MEMORY` references in hook sources
- ✅ `paiPath` search in `Releases/v4.0.3+/`: **zero** matches after deletion + doc substitution
- ✅ CI symbol guard (from merged #105) passes all 13 required-symbol checks against this commit

## Next for the #100 series

1. Close #103 with a comment pointing at this PR.
2. Open a tracking issue for the automated MEMORY migrator (will reference this PR's documentation-only approach as the temporary measure).
3. Leave the `statusLine.command` relocation and the `ebc8130` scope-creep post-mortem for separate follow-ups — neither belongs in this refactor.