### PR TITLE
Fix residual .claude/PAI literals in executable code (#108)

### DIFF
--- a/Releases/v4.0.3+/.claude/PAI/ACTIONS/lib/runner.v2.ts
+++ b/Releases/v4.0.3+/.claude/PAI/ACTIONS/lib/runner.v2.ts
@@ -29,8 +29,9 @@ const USER_ACTIONS_DIR = join(ACTIONS_DIR, "..", "USER", "ACTIONS");
  * Local LLM provider using PAI's Inference tool
  */
 async function createLocalLLM(): Promise<ActionCapabilities["llm"]> {
+  const PAI_ROOT = process.env.PAI_DIR || join(process.env.HOME!, ".pai");
   const inferenceModule = await import(
-    join(process.env.HOME!, ".claude/PAI/Tools/Inference.ts")
+    join(PAI_ROOT, "PAI/Tools/Inference.ts")
   );
   const { inference } = inferenceModule;
 

--- a/Releases/v4.0.3+/.claude/PAI/Tools/RebuildPAI.ts
+++ b/Releases/v4.0.3+/.claude/PAI/Tools/RebuildPAI.ts
@@ -13,7 +13,8 @@ import { readdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 
 const HOME = process.env.HOME!;
-const PAI_DIR = join(HOME, ".claude/PAI");
+const PAI_ROOT = process.env.PAI_DIR || join(HOME, ".pai");
+const PAI_DIR = join(PAI_ROOT, "PAI");
 const COMPONENTS_DIR = join(PAI_DIR, "Components");
 const ALGORITHM_DIR = join(COMPONENTS_DIR, "Algorithm");
 const OUTPUT_FILE = join(PAI_DIR, "SKILL.md");


### PR DESCRIPTION
## Summary

- Fix 2 residual hardcoded `.claude/PAI` path literals in executable code under `Releases/v4.0.3+/.claude/PAI/`, so both files now resolve via `process.env.PAI_DIR || ~/.pai` matching the repo convention (`Tools/algorithm.ts`, `Tools/FailureCapture.ts`, `hooks/lib/paths.ts`).
- Partial fix for issue #108 — specifically the canonical `.claude/PAI/` subtree residuals in executable code.
- Spun out a sibling issue #116 for 4 additional residuals found in the `.claude/skills/` subtree (same bug class, outside #108's plan scope).

## What changed

| File | Change |
|---|---|
| `Releases/v4.0.3+/.claude/PAI/Tools/RebuildPAI.ts` | Introduce `PAI_ROOT = process.env.PAI_DIR \|\| ~/.pai`; `PAI_DIR` now = `PAI_ROOT/PAI` |
| `Releases/v4.0.3+/.claude/PAI/ACTIONS/lib/runner.v2.ts` | Resolve `PAI_ROOT` inside `createLocalLLM()`; dynamic import of `Inference.ts` uses it |

Net diff: 4 insertions, 2 deletions.

## Plan-vs-reality finding

`Plans/2026-04-14-two-root-separation-followups.md` listed 10 files for #108. **8 of those 10 were already clean on this branch** — likely handled between commits #101 and #106. The remaining 2 are the ones fixed here. The OBSERVE-phase verification used:

```bash
grep -rn '~/.claude/PAI' Releases/v4.0.3+/.claude/PAI/
```

which returned zero hits before AND after these edits (the stale cases in the remaining 2 files used `${HOME}/.claude/PAI` form without a literal `~`, so they required a broader `.claude/PAI` grep to catch).

## Out of scope — intentionally untouched

- **`~/.claude/settings.json`** reference at `RebuildPAI.ts:21` — correct per two-root architecture; settings live in `CLAUDE_CONFIG_DIR`, not `PAI_DIR`.
- **The 102-line Algorithm-spec gap** in `Releases/v4.0.3+/.claude/PAI/Algorithm/v3.7.0.md` — separate reconciliation problem per plan doc; explicitly not bundled.
- **4 residual hits in `Releases/v4.0.3+/.claude/skills/`** — filed as issue #116. Same bug class, outside plan's canonical-tree scope. Needs its own PR since fixing these likely requires parallel edits in `Packs/` source-of-truth tree (sync direction to be determined).
- **Runtime (`~/.claude/` and `~/.pai/`)** — no runtime touches per plan constraint.

## Verification

- `grep -rn '\.claude/PAI' Releases/v4.0.3+/.claude/PAI/` → **zero hits** after the fix
- `bun build --target=bun Releases/v4.0.3+/.claude/PAI/Tools/RebuildPAI.ts` → bundles cleanly in 6ms
- `bun build --target=bun Releases/v4.0.3+/.claude/PAI/ACTIONS/lib/runner.v2.ts` → same pre-existing `ajv` module-resolution error as before (at `types.v2.ts:164`, unrelated to this PR's edit at line 32-34)
- Settings.json reference at `RebuildPAI.ts:21` unchanged
- No changes to `v3.7.0.md`

## Test plan

- [ ] `grep -rn '\\.claude/PAI' Releases/v4.0.3+/.claude/PAI/` returns zero hits
- [ ] CI (if the symbol-guard added in #105 includes a `.claude/PAI` check) passes; if no such guard exists, consider adding one in a followup
- [ ] Manual sanity: run `bun Releases/v4.0.3+/.claude/PAI/Tools/RebuildPAI.ts` in an env where `PAI_DIR=~/.pai` is set and confirm it resolves `Components/` under `~/.pai/PAI/Components/` (not `~/.claude/PAI/Components/`)
- [ ] `runner.v2.ts` smoke test: invoke an action that uses `createLocalLLM()` and confirm the `Inference.ts` import resolves

## References

- Partial fix for #108
- Related: #116 (skills/ tree residuals, spun out from this investigation)
- Plan: `Plans/2026-04-14-two-root-separation-followups.md`
- Parent umbrella: #98 (two-root separation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)