### PR TITLE
Fix Learning Apply.md phantom path + feedback mislabel

### DIFF
--- a/Packs/Learning/src/Workflows/Apply.md
+++ b/Packs/Learning/src/Workflows/Apply.md
@@ -66,8 +66,8 @@ For each ACCEPTED proposal, read the current state of its target file:
 | Target | File to Read |
 |--------|-------------|
 | Algorithm spec | Read `~/.pai/PAI/Algorithm/LATEST` to get version, then read `~/.pai/PAI/Algorithm/v{VERSION}.md` |
-| AISTEERINGRULES.md | Read `~/.claude/AISTEERINGRULES.md` |
-| Feedback memories | Read the PAI memory directory `~/.claude/projects/*/memory/` to understand existing structure |
+| AISTEERINGRULES.md | Read `~/.pai/PAI/AISTEERINGRULES.md` |
+| Feedback memories | Read the PAI feedback memory directory `~/.pai/MEMORY/FEEDBACK/` to understand existing structure. If the directory does not exist yet, there are no existing feedback memories. |
 
 ### Step 3: Generate Concrete Diffs
 
@@ -79,7 +79,7 @@ For each ACCEPTED proposal, generate a concrete edit against the **current** tar
 |--------|---------------------|
 | **Algorithm spec** | Section-aware edit. Read the spec structure, identify the correct section using the Algorithm Section Routing Table (from Review workflow). Generate a diff that inserts, replaces, or augments the specific section. Most changes are additions or rewording of existing steps. |
 | **AISTEERINGRULES.md** | Append. Almost always a new rule added to an existing section. Identify the appropriate section in AISTEERINGRULES.md and generate an append diff. Simplest target. |
-| **Feedback memories** | File-based. Generate a new memory file with proper frontmatter (name, description, type: feedback). The file will be written to the PAI memory directory. |
+| **Feedback memories** | File-based. Generate a new memory file with proper frontmatter (name, description, type: feedback). The file will be written to `~/.pai/MEMORY/FEEDBACK/` (global, not per-cwd). |
 
 **Edge cases to handle:**
 - **Target file changed since proposal:** Diffs are generated against the current file, not a snapshot from proposal time. If someone already made the change by hand, detect the overlap and flag it rather than duplicating.

--- a/Releases/v4.0.3+/.claude/skills/Learning/Workflows/Apply.md
+++ b/Releases/v4.0.3+/.claude/skills/Learning/Workflows/Apply.md
@@ -66,8 +66,8 @@ For each ACCEPTED proposal, read the current state of its target file:
 | Target | File to Read |
 |--------|-------------|
 | Algorithm spec | Read `~/.pai/PAI/Algorithm/LATEST` to get version, then read `~/.pai/PAI/Algorithm/v{VERSION}.md` |
-| AISTEERINGRULES.md | Read `~/.claude/AISTEERINGRULES.md` |
-| Feedback memories | Read the PAI memory directory `~/.claude/projects/*/memory/` to understand existing structure |
+| AISTEERINGRULES.md | Read `~/.pai/PAI/AISTEERINGRULES.md` |
+| Feedback memories | Read the PAI feedback memory directory `~/.pai/MEMORY/FEEDBACK/` to understand existing structure. If the directory does not exist yet, there are no existing feedback memories. |
 
 ### Step 3: Generate Concrete Diffs
 
@@ -79,7 +79,7 @@ For each ACCEPTED proposal, generate a concrete edit against the **current** tar
 |--------|---------------------|
 | **Algorithm spec** | Section-aware edit. Read the spec structure, identify the correct section using the Algorithm Section Routing Table (from Review workflow). Generate a diff that inserts, replaces, or augments the specific section. Most changes are additions or rewording of existing steps. |
 | **AISTEERINGRULES.md** | Append. Almost always a new rule added to an existing section. Identify the appropriate section in AISTEERINGRULES.md and generate an append diff. Simplest target. |
-| **Feedback memories** | File-based. Generate a new memory file with proper frontmatter (name, description, type: feedback). The file will be written to the PAI memory directory. |
+| **Feedback memories** | File-based. Generate a new memory file with proper frontmatter (name, description, type: feedback). The file will be written to `~/.pai/MEMORY/FEEDBACK/` (global, not per-cwd). |
 
 **Edge cases to handle:**
 - **Target file changed since proposal:** Diffs are generated against the current file, not a snapshot from proposal time. If someone already made the change by hand, detect the overlap and flag it rather than duplicating.


### PR DESCRIPTION
## Summary

Fixes 2 of the 3 bugs in #109:

- **Bug 1 (Mislabel):** `Apply.md:70,82` called `~/.claude/projects/*/memory/` "the PAI memory directory" — it isn't. That path is Claude Code's per-cwd auto-memory, not PAI memory.
- **Bug 2 (Phantom path):** `Apply.md:69` read AISTEERINGRULES from `~/.claude/AISTEERINGRULES.md`, a file that has never existed at that path. Canonical location is `~/.pai/PAI/AISTEERINGRULES.md`.
- **Bug 3 (stale Algorithm read):** Already fixed in repo prior to this branch. `Apply.md:68` in both copies already reads `~/.pai/PAI/Algorithm/LATEST`. Not part of this PR's diff.

## Design decision: Path B selected

Issue #109 offered two paths for the feedback-memory home. **Path B — PAI-native directory at `~/.pai/MEMORY/FEEDBACK/`** was chosen over Path A (keep per-cwd Claude Code auto-memory, just rename the label).

**Rationale:** Path A cements per-cwd siloing as intentional. Path B gives feedback memories a proper PAI-native home that's global across working directories and no longer relies on piggybacking on Claude Code harness features.

## Scope (repo-only, surgical)

Two files, three line edits each:

- `Packs/Learning/src/Workflows/Apply.md` — lines 69, 70, 82
- `Releases/v4.0.3+/.claude/skills/Learning/Workflows/Apply.md` — lines 69, 70, 82

6 lines changed, 6 lines added. No runtime modifications. No commits to `~/.pai/skills/`.

**Audited and confirmed clean** (no edits needed): `Check.md` and `Review.md` in both repo copies — neither references the buggy paths.

## ⚠️ Part 1 of 2 — follow-up required

This PR is **Part 1** of Path B. Part 2 is an imminent follow-up (per author's commitment) covering:

1. Create `~/.pai/MEMORY/FEEDBACK/` at runtime (will be handled by installer or first `/learn apply`)
2. Add a loader so feedback memories are re-surfaced at SessionStart — likely via `LoadContext.hook.ts` or a new entry in `settings.json → loadAtStartup`
3. Add `FEEDBACK/` to the canonical directory structure documented in `Releases/v4.0.3+/.claude/PAI/MEMORYSYSTEM.md`
4. Decide whether to migrate existing files from `~/.claude/projects/*/memory/` to the new location

**Known temporary regression between Part 1 and Part 2:** Between merge of this PR and merge of Part 2, the learning loop's read side is temporarily broken — feedback memories written under the new path will not be loaded at SessionStart by any mechanism. Under the pre-PR state, Claude Code auto-memory would at least load them per-cwd. This is accepted because Part 2 lands very soon.

## Out of scope

- **Runtime `~/.pai/skills/Learning/Workflows/Apply.md`** — repo-only edit constraint from `Plans/2026-04-14-two-root-separation-followups.md`
- **4-byte checkbox-default drift** between `Packs/Learning/src/Workflows/Apply.md` and `Releases/v4.0.3+/.claude/skills/Learning/Workflows/Apply.md` — unrelated pre-existing drift
- **`SKILL.md` / `README.md` / `Review.md` "feedback memories" concept references** — none contain paths, so no path edits are needed
- **`MEMORYSYSTEM.md` addition of `FEEDBACK/` to architecture** — Part 2

## Related

- Closes bugs 1 and 2 of #109 (bug 3 was already closed in repo)
- Related context: #108 (two-root separation), #97 (memory system overlap), #98 (parent architecture issue)
- Planning reference: `Plans/2026-04-14-two-root-separation-followups.md`

## Test plan

- [ ] `grep '\.claude/AISTEERINGRULES' Packs/Learning/ Releases/v4.0.3+/.claude/skills/Learning/` returns zero results
- [ ] `grep 'PAI memory directory' Packs/Learning/ Releases/v4.0.3+/.claude/skills/Learning/` returns zero results
- [ ] Manual inspection of `Apply.md:69,70,82` in both repo copies confirms the PAI-native paths
- [ ] Runtime `~/.pai/skills/Learning/Workflows/Apply.md` mtime is unchanged by this PR (verified locally: Apr 7 21:05)
- [ ] Part 2 follow-up tracked before `/learn apply` is next invoked against real ACCEPTED proposals