### PR TITLE
Part 2 of #109: feedback loader + LEARNING/FEEDBACK/ home

### DIFF
--- a/Packs/Learning/src/Workflows/Apply.md
+++ b/Packs/Learning/src/Workflows/Apply.md
@@ -67,7 +67,7 @@ For each ACCEPTED proposal, read the current state of its target file:
 |--------|-------------|
 | Algorithm spec | Read `~/.pai/PAI/Algorithm/LATEST` to get version, then read `~/.pai/PAI/Algorithm/v{VERSION}.md` |
 | AISTEERINGRULES.md | Read `~/.pai/PAI/AISTEERINGRULES.md` |
-| Feedback memories | Read the PAI feedback memory directory `~/.pai/MEMORY/FEEDBACK/` to understand existing structure. If the directory does not exist yet, there are no existing feedback memories. |
+| Feedback memories | Read the PAI feedback memory directory `~/.pai/MEMORY/LEARNING/FEEDBACK/` to understand existing structure. If the directory does not exist yet, there are no existing feedback memories. |
 
 ### Step 3: Generate Concrete Diffs
 
@@ -79,7 +79,7 @@ For each ACCEPTED proposal, generate a concrete edit against the **current** tar
 |--------|---------------------|
 | **Algorithm spec** | Section-aware edit. Read the spec structure, identify the correct section using the Algorithm Section Routing Table (from Review workflow). Generate a diff that inserts, replaces, or augments the specific section. Most changes are additions or rewording of existing steps. |
 | **AISTEERINGRULES.md** | Append. Almost always a new rule added to an existing section. Identify the appropriate section in AISTEERINGRULES.md and generate an append diff. Simplest target. |
-| **Feedback memories** | File-based. Generate a new memory file with proper frontmatter (name, description, type: feedback). The file will be written to `~/.pai/MEMORY/FEEDBACK/` (global, not per-cwd). |
+| **Feedback memories** | File-based. Generate a new memory file with proper frontmatter (name, description, type: feedback). The file will be written to `~/.pai/MEMORY/LEARNING/FEEDBACK/` (global, not per-cwd). |
 
 **Edge cases to handle:**
 - **Target file changed since proposal:** Diffs are generated against the current file, not a snapshot from proposal time. If someone already made the change by hand, detect the overlap and flag it rather than duplicating.
@@ -164,7 +164,7 @@ For each proposal where the checkbox is checked (`[x]`):
 |--------|-------------|
 | **Algorithm spec** | Section-aware Edit. Read the current spec, find the target section, apply the insert/replace/augment using the Edit tool. Verify the edit was applied correctly by re-reading the section. |
 | **AISTEERINGRULES.md** | Append. Read the current file, find the target section, use the Edit tool to append the new rule. |
-| **Feedback memories** | Write new file. Use the Write tool to create a new memory file at the appropriate path with proper frontmatter. Then update MEMORY.md index if applicable. |
+| **Feedback memories** | Write new file. Ensure the destination directory exists first (`mkdir -p ~/.pai/MEMORY/LEARNING/FEEDBACK/`) — idempotent bootstrap, only has effect on the first apply run after a fresh install. Then use the Write tool to create a new memory file under that directory with proper frontmatter. Then update MEMORY.md index if applicable. |
 
 For each proposal where the checkbox is unchecked (`[ ]`):
 - Skip — do not apply

--- a/Releases/v4.0.3+/.claude/PAI/MEMORYSYSTEM.md
+++ b/Releases/v4.0.3+/.claude/PAI/MEMORYSYSTEM.md
@@ -55,8 +55,10 @@ Harvesting (periodic):
 │   │       └── weekly-patterns.md
 │   ├── REFLECTIONS/        # Algorithm performance reflections
 │   │   └── algorithm-reflections.jsonl
-│   └── SIGNALS/            # User satisfaction ratings
-│       └── ratings.jsonl
+│   ├── SIGNALS/            # User satisfaction ratings
+│   │   └── ratings.jsonl
+│   └── FEEDBACK/           # PAI-native behavioral feedback memories (Path B, issue #109)
+│       └── feedback_*.md
 ├── RESEARCH/               # Agent output captures
 │   └── YYYY-MM/
 ├── SECURITY/               # Security audit events
@@ -139,6 +141,7 @@ This is the actual "firehose" - every message, tool call, and response. PAI leve
 - `LEARNING/SYNTHESIS/YYYY-MM/` - Aggregated pattern analysis (weekly/monthly reports)
 - `LEARNING/REFLECTIONS/algorithm-reflections.jsonl` - Algorithm performance reflections (Q1/Q2/Q3 from LEARN phase)
 - `LEARNING/SIGNALS/ratings.jsonl` - All user satisfaction ratings
+- `LEARNING/FEEDBACK/feedback_*.md` - PAI-native behavioral feedback memories (flat .md files with YAML frontmatter)
 
 **Categorization logic:**
 | Directory | When Used | Example Triggers |
@@ -148,6 +151,7 @@ This is the actual "firehose" - every message, tool call, and response. PAI leve
 | `FAILURES/` | Full context for low ratings (1-3) | severe frustration, repeated errors |
 | `REFLECTIONS/` | Algorithm performance analysis | per-session 3-question reflection from LEARN phase |
 | `SYNTHESIS/` | Pattern aggregation | weekly analysis, recurring issues |
+| `FEEDBACK/` | Behavioral feedback memories (PAI-native) | DO-MORE patterns accepted via `/learn apply`; hand-written feedback |
 
 ### LEARNING/FAILURES/ - Full Context Failure Analysis
 
@@ -184,6 +188,20 @@ This is the actual "firehose" - every message, tool call, and response. PAI leve
 1. Root cause identification - what sequence led to the failure?
 2. Pattern detection - do similar failures share characteristics?
 3. Systemic improvement - what changes would prevent this class of failure?
+
+### LEARNING/FEEDBACK/ - PAI-Native Behavioral Feedback Memories
+
+**What populates it:**
+- `/learn apply` workflow (Packs/Learning/src/Workflows/Apply.md, Step 7) when a DO-MORE behavioral pattern is accepted
+- Hand-written feedback files placed directly under this directory by the user
+
+**Content:** Flat `.md` files with YAML frontmatter (`name`, `description`, `type: feedback`) and a free-form body describing the behavior to reinforce
+**Format:** `feedback_{short_slug}.md` — no month buckets (feedback memories are durable, low-volume, and globally relevant across cwds)
+**Purpose:** Path B home for PAI-native behavioral feedback under issue #109. Replaces the prior per-cwd siloing of feedback memories under `~/.claude/projects/<cwd-slug>/memory/feedback_*.md`, which was mislabeled as "the PAI memory directory" in pre-Part-1 Apply.md.
+
+**Readback at SessionStart:** `learning-readback.ts → loadFeedbackMemories(count)` reads the N most recent files by filename-sort-descending, extracts `name` + `description`, and surfaces them via `LoadContext.hook.ts` in the same `<system-reminder>` block as the other learning readback sections. Controlled by the `dynamicContext.learningReadback` flag in `settings.json` (default: enabled).
+
+**Migration status:** Existing pre-Part-1 feedback files under `~/.claude/projects/*/memory/feedback_*.md` are left dormant. They are no longer the authoritative home for new feedback. A user who wants the pre-existing files re-surfaced at SessionStart can copy them manually into `~/.pai/MEMORY/LEARNING/FEEDBACK/`. No automated migration is provided — the prior files remain readable via their original mechanism.
 
 ### RESEARCH/ - Agent Outputs
 
@@ -337,6 +355,12 @@ bun run ~/.pai/PAI/Tools/LearningPatternSynthesis.ts --week
 ---
 
 ## Migration History
+
+**2026-04-14:** v7.3 - PAI-native feedback memory home (Path B, issue #109)
+- Added `LEARNING/FEEDBACK/` directory for behavioral feedback memories
+- Part 1 (PR #118, squash `bb73f89`): Apply.md path strings moved off Claude Code per-cwd auto-memory; AISTEERINGRULES phantom-file read path corrected
+- Part 2 (this change): directory location finalized under `LEARNING/`; loader added to `learning-readback.ts` (`loadFeedbackMemories`); wired into `LoadContext.hook.ts` via the existing `learningReadback` flag; Apply.md Step 7 updated to `mkdir -p` on first write for idempotent bootstrap
+- Existing pre-Part-1 feedback files under `~/.claude/projects/*/memory/feedback_*.md` left dormant with manual-migration instructions above
 
 **2026-02-22:** v7.2 - PRD Consolidation (v4.0 work directories)
 - Consolidated META.yaml, ISC.json, THREAD.md into single PRD.md per work directory

--- a/Releases/v4.0.3+/.claude/hooks/LoadContext.hook.ts
+++ b/Releases/v4.0.3+/.claude/hooks/LoadContext.hook.ts
@@ -36,7 +36,7 @@ import { readFileSync, existsSync, readdirSync } from 'fs';
 import { join } from 'path';
 import { getConfigDir, codePath } from './lib/paths';
 import { recordSessionStart } from './lib/notifications';
-import { loadLearningDigest, loadWisdomFrames, loadFailurePatterns, loadSignalTrends } from './lib/learning-readback';
+import { loadLearningDigest, loadWisdomFrames, loadFailurePatterns, loadSignalTrends, loadFeedbackMemories } from './lib/learning-readback';
 
 interface DynamicContextConfig {
   relationshipContext?: boolean;
@@ -483,12 +483,14 @@ async function main() {
       const wisdomFrames = loadWisdomFrames();
       const failurePatterns = loadFailurePatterns();
       const signalTrends = loadSignalTrends();
+      const feedbackMemories = loadFeedbackMemories();
 
       const learningParts: string[] = [];
       if (signalTrends) learningParts.push(signalTrends);
       if (wisdomFrames) learningParts.push(wisdomFrames);
       if (learningDigest) learningParts.push(learningDigest);
       if (failurePatterns) learningParts.push(failurePatterns);
+      if (feedbackMemories) learningParts.push(feedbackMemories);
 
       learningContext = learningParts.length > 0
         ? '\n## Learning Context (auto-loaded)\n\n' + learningParts.join('\n\n')

--- a/Releases/v4.0.3+/.claude/hooks/lib/learning-readback.ts
+++ b/Releases/v4.0.3+/.claude/hooks/lib/learning-readback.ts
@@ -381,3 +381,48 @@ export function loadBehavioralTrends(): string | null {
     return null;
   }
 }
+
+/**
+ * Load recent PAI-native feedback memories from MEMORY/LEARNING/FEEDBACK/.
+ *
+ * Feedback memories are flat .md files (no month buckets) with YAML frontmatter
+ * containing `name`, `description`, and `type: feedback`. They are written by
+ * the Learning skill's Apply workflow when a DO-MORE behavioral pattern is
+ * accepted — see issue #109 and Packs/Learning/src/Workflows/Apply.md.
+ *
+ * Returns the N most recent (by filename sort descending) with name+description
+ * extracted for compact context injection. Returns null if the directory does
+ * not exist or contains no feedback files — matches the null-return pattern of
+ * the other readback functions above.
+ */
+export function loadFeedbackMemories(count: number = 5): string | null {
+  const feedbackDir = codePath('MEMORY', 'LEARNING', 'FEEDBACK');
+  if (!existsSync(feedbackDir)) return null;
+
+  const entries: string[] = [];
+
+  try {
+    const files = readdirSync(feedbackDir)
+      .filter(f => f.endsWith('.md') && f !== 'README.md' && f !== 'MEMORY.md')
+      .sort()
+      .reverse()
+      .slice(0, count);
+
+    for (const file of files) {
+      try {
+        const content = readFileSync(join(feedbackDir, file), 'utf-8');
+        const nameMatch = content.match(/^name:\s*(.+)$/m);
+        const descMatch = content.match(/^description:\s*(.+)$/m);
+        if (nameMatch && descMatch) {
+          const name = nameMatch[1].trim().substring(0, 40);
+          const desc = descMatch[1].trim().substring(0, 80);
+          entries.push(`${name} — ${desc}`);
+        }
+      } catch { /* skip unreadable files */ }
+    }
+  } catch { /* skip if dir scan fails */ }
+
+  if (entries.length === 0) return null;
+
+  return `**Feedback Memories (PAI-native):**\n${entries.map(e => `  • ${e}`).join('\n')}`;
+}

--- a/Releases/v4.0.3+/.claude/skills/Learning/Workflows/Apply.md
+++ b/Releases/v4.0.3+/.claude/skills/Learning/Workflows/Apply.md
@@ -67,7 +67,7 @@ For each ACCEPTED proposal, read the current state of its target file:
 |--------|-------------|
 | Algorithm spec | Read `~/.pai/PAI/Algorithm/LATEST` to get version, then read `~/.pai/PAI/Algorithm/v{VERSION}.md` |
 | AISTEERINGRULES.md | Read `~/.pai/PAI/AISTEERINGRULES.md` |
-| Feedback memories | Read the PAI feedback memory directory `~/.pai/MEMORY/FEEDBACK/` to understand existing structure. If the directory does not exist yet, there are no existing feedback memories. |
+| Feedback memories | Read the PAI feedback memory directory `~/.pai/MEMORY/LEARNING/FEEDBACK/` to understand existing structure. If the directory does not exist yet, there are no existing feedback memories. |
 
 ### Step 3: Generate Concrete Diffs
 
@@ -79,7 +79,7 @@ For each ACCEPTED proposal, generate a concrete edit against the **current** tar
 |--------|---------------------|
 | **Algorithm spec** | Section-aware edit. Read the spec structure, identify the correct section using the Algorithm Section Routing Table (from Review workflow). Generate a diff that inserts, replaces, or augments the specific section. Most changes are additions or rewording of existing steps. |
 | **AISTEERINGRULES.md** | Append. Almost always a new rule added to an existing section. Identify the appropriate section in AISTEERINGRULES.md and generate an append diff. Simplest target. |
-| **Feedback memories** | File-based. Generate a new memory file with proper frontmatter (name, description, type: feedback). The file will be written to `~/.pai/MEMORY/FEEDBACK/` (global, not per-cwd). |
+| **Feedback memories** | File-based. Generate a new memory file with proper frontmatter (name, description, type: feedback). The file will be written to `~/.pai/MEMORY/LEARNING/FEEDBACK/` (global, not per-cwd). |
 
 **Edge cases to handle:**
 - **Target file changed since proposal:** Diffs are generated against the current file, not a snapshot from proposal time. If someone already made the change by hand, detect the overlap and flag it rather than duplicating.
@@ -164,7 +164,7 @@ For each proposal where the checkbox is checked (`[x]`):
 |--------|-------------|
 | **Algorithm spec** | Section-aware Edit. Read the current spec, find the target section, apply the insert/replace/augment using the Edit tool. Verify the edit was applied correctly by re-reading the section. |
 | **AISTEERINGRULES.md** | Append. Read the current file, find the target section, use the Edit tool to append the new rule. |
-| **Feedback memories** | Write new file. Use the Write tool to create a new memory file at the appropriate path with proper frontmatter. Then update MEMORY.md index if applicable. |
+| **Feedback memories** | Write new file. Ensure the destination directory exists first (`mkdir -p ~/.pai/MEMORY/LEARNING/FEEDBACK/`) — idempotent bootstrap, only has effect on the first apply run after a fresh install. Then use the Write tool to create a new memory file under that directory with proper frontmatter. Then update MEMORY.md index if applicable. |
 
 For each proposal where the checkbox is unchecked (`[ ]`):
 - Skip — do not apply


### PR DESCRIPTION
## Summary

Part 2 of issue #109. Closes the learning loop under Path B that Part 1 (#118, squash `bb73f89`) left half-open.

- **Directory finalized under `LEARNING/`.** New home is `~/.pai/MEMORY/LEARNING/FEEDBACK/`, nested under `LEARNING/` to match the existing convention where every learning-category artifact (`FAILURES`, `SYNTHESIS`, `REFLECTIONS`, `SIGNALS`) lives under `LEARNING/`. This supersedes Part 1's top-level path strings.
- **Loader added.** `learning-readback.ts` exports `loadFeedbackMemories(count = 5)` — flat-readdir loader that extracts YAML `name` + `description` from each feedback-memory file and returns `null` on missing/empty directories (matches existing readback pattern).
- **SessionStart wire-up.** `LoadContext.hook.ts` imports and invokes the loader inside the existing `learningReadback` block so feedback memories get injected into session context alongside signals, wisdom, digest, and failure patterns.
- **Idempotent bootstrap.** `Apply.md` Step 7 (both pack-src and release-staged copies) runs `mkdir -p` before first write, resolving the ENOENT window between Part 1 merge and this PR.
- **Canonical doc update.** `MEMORYSYSTEM.md` gains: tree diagram row, categorization table row, new `LEARNING/FEEDBACK/` subsection (purpose / format / readback integration / migration status), and a v7.3 Migration History entry.

## Key decisions (see PRD for full rationale)

| # | Decision | Why |
|---|---|---|
| D1 | `LEARNING/FEEDBACK/` not top-level `FEEDBACK/` | Matches existing MEMORYSYSTEM convention; `learning-readback.ts` already iterates `LEARNING/` by month, so the loader extends a proven pattern |
| D2 | Additive function in `learning-readback.ts`, not a new lib | Zero new coupling, one import line in LoadContext.hook.ts |
| D4 | mkdir inline in Apply.md Step 7 | Installer never touches `~/.pai/` (per Plans doc), so it can't help; a new hook is overkill for one `mkdir` |
| D5 | Leave pre-Part-1 per-cwd files dormant | Automated migration would touch Claude Code's zone; manual migration instructions documented in MEMORYSYSTEM.md instead |
| D6 | Filename-descending sort in loader | No `fs.stat()` call per file; slug-based filenames don't benefit from mtime ordering. Called out in PRD for future revisit |

## Scope excluded (intentional)

- **No runtime edits** under `~/.pai/skills/` or `~/.pai/MEMORY/LEARNING/FEEDBACK/` — repo-only per Plans/2026-04-14-two-root-separation-followups.md
- **No automated migration** of the 15 existing per-cwd `feedback_*.md` files under `~/.claude/projects/*/memory/` — left dormant with manual migration docs
- **No `settings.json` schema change** — reuses the existing `dynamicContext.learningReadback` flag as the gate
- **No reconciliation of the 4-byte pack-src vs release-staged divergence** on Apply.md checkbox-default semantics (`UNCHECKED` vs `CHECKED`) — that's a pre-existing drift, a separate concern
- **No edits to historical Plans docs** (`Plans/2026-04-14-two-root-separation-followups.md`, `Plans/imperative-tinkering-dawn.md`) that still contain the phrase \"PAI memory directory\" — those are write-once historical artifacts

## Test plan

- [x] Loader fixture test — 3 cases (2-file normal / missing dir / empty dir) all pass with expected output
- [x] `bun build --no-bundle` transpile passes on both modified `.ts` files
- [x] `grep 'PAI memory directory'` — zero live references in Learning pack workflow files; remaining hits are in historical Plans docs and one explanatory quote inside `MEMORYSYSTEM.md` itself
- [x] `git diff --stat` confirms only 5 files touched; no `~/.pai/skills/` edits; no `settings.json` changes
- [x] `Review.md`, `Check.md`, `SKILL.md` audited by full read — no stale semantics from Path B
- [ ] Runtime end-to-end (manual post-merge): run `/learn apply` with an ACCEPTED DO-MORE proposal, confirm file lands under `~/.pai/MEMORY/LEARNING/FEEDBACK/`, start a new session, confirm `loadFeedbackMemories` surfaces it in the LoadContext output

## Related

- Closes part of #109 (issue stays open only if you want to track additional follow-ups; otherwise can be closed with this PR)
- Follows #118 (Part 1, squash `bb73f89`)
- Tracked in `Plans/2026-04-14-two-root-separation-followups.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)