### PR TITLE
Make installer clone URL configurable for fork installs (#115)

### DIFF
--- a/Releases/v4.0.3+/.claude/PAI-Install/README.md
+++ b/Releases/v4.0.3+/.claude/PAI-Install/README.md
@@ -1,6 +1,6 @@
 # PAI Installer v4.0
 
-> Install [PAI (Personal AI Infrastructure)](https://github.com/danielmiessler/PAI) with a single command.
+> Install [PAI (Personal AI Infrastructure)](https://github.com/danielmiessler/Personal_AI_Infrastructure) with a single command.
 
 ## Quick Start
 
@@ -23,6 +23,30 @@ That's it. The script handles everything:
 - Internet connection
 
 Everything else (Bun, Git, Claude Code) is installed automatically.
+
+---
+
+## Installing from a Fork
+
+By default the installer clones from `github.com/danielmiessler/Personal_AI_Infrastructure`. If you are running from a fork and want fresh installs to pull from your fork instead, pass the fork URL to the installer. Three equivalent mechanisms are supported, checked in this priority order:
+
+1. **`--repo-url=` CLI flag** — highest priority, wins over everything:
+
+   ```bash
+   bash PAI-Install/install.sh --repo-url=https://github.com/YOUR_USER/pai.git
+   ```
+
+2. **`PAI_REPO_URL` environment variable** — useful for CI and scripted installs:
+
+   ```bash
+   PAI_REPO_URL=https://github.com/YOUR_USER/pai.git bash PAI-Install/install.sh
+   ```
+
+3. **Existing `origin` remote preservation** — if `~/.claude/.git/` already exists with a remote configured (for example, you previously cloned a fork manually), the installer detects it via `git remote get-url origin` and uses that URL for re-clone/init operations. This means users who have already switched their existing install to a fork can re-run the installer without re-specifying the URL.
+
+If none of the above apply, the installer falls back to the upstream default. The upgrade path (`git pull origin main` against an existing installation) always respects whatever remote is already configured, and now logs the remote URL it is pulling from so fork users can confirm the right origin is in use.
+
+See GitHub issue [#115](https://github.com/virtualian/pai/issues/115) for design context.
 
 ---
 
@@ -325,4 +349,4 @@ bun run PAI-Install/main.ts --mode gui
 
 ## License
 
-Part of [PAI — Personal AI Infrastructure](https://github.com/danielmiessler/PAI).
+Part of [PAI — Personal AI Infrastructure](https://github.com/danielmiessler/Personal_AI_Infrastructure).

--- a/Releases/v4.0.3+/.claude/PAI-Install/cli/display.ts
+++ b/Releases/v4.0.3+/.claude/PAI-Install/cli/display.ts
@@ -85,7 +85,7 @@ export function printBanner(): void {
   print(`           ${c.navy}████${c.reset}        ${c.blue}████${c.reset}${c.lightBlue}████${c.reset}   ${sep}`);
   print("");
   print("");
-  print(`                       ${c.steel}→${c.reset} ${c.blue}github.com/danielmiessler/PAI${c.reset}`);
+  print(`                       ${c.steel}→${c.reset} ${c.blue}danielmiessler/Personal_AI_Infrastructure${c.reset}`);
   print("");
   print(`${c.steel}┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛${c.reset}`);
   print("");

--- a/Releases/v4.0.3+/.claude/PAI-Install/engine/actions.ts
+++ b/Releases/v4.0.3+/.claude/PAI-Install/engine/actions.ts
@@ -12,6 +12,7 @@ import type { InstallState, EngineEventHandler, DetectionResult } from "./types"
 import { PAI_VERSION, ALGORITHM_VERSION } from "./types";
 import { detectSystem, validateElevenLabsKey } from "./detect";
 import { generateSettingsJson } from "./config-gen";
+import { resolveRepoUrl, readOriginRemote } from "./repo-url";
 
 /**
  * Remove duplicate bun PATH entries from shell config.
@@ -508,6 +509,12 @@ export async function runRepository(
     // Check if it's a git repo
     const isGitRepo = existsSync(join(paiDir, ".git"));
     if (isGitRepo) {
+      // Helps fork installs confirm their origin is what they expect (#115).
+      const currentRemote = readOriginRemote(paiDir);
+      if (currentRemote) {
+        await emit({ event: "message", content: `Pulling updates from ${currentRemote}` });
+      }
+
       const pullResult = tryExec(`cd "${paiDir}" && git pull origin main 2>&1`, 60000);
       if (pullResult !== null) {
         await emit({ event: "message", content: "PAI repository updated from GitHub." });
@@ -518,7 +525,15 @@ export async function runRepository(
       await emit({ event: "message", content: "Existing installation is not a git repo. Preserving current files." });
     }
   } else {
-    // Fresh install — clone repo
+    // Fresh install — clone repo. See resolveRepoUrl for priority order (#115).
+    const resolved = resolveRepoUrl(paiDir);
+    if (resolved.source !== "default") {
+      await emit({
+        event: "message",
+        content: `Using repo URL from ${resolved.sourceLabel}: ${resolved.url}`,
+      });
+    }
+
     await emit({ event: "progress", step: "repository", percent: 20, detail: "Cloning PAI repository..." });
 
     if (!existsSync(paiDir)) {
@@ -526,7 +541,7 @@ export async function runRepository(
     }
 
     const cloneResult = tryExec(
-      `git clone https://github.com/danielmiessler/PAI.git "${paiDir}" 2>&1`,
+      `git clone "${resolved.url}" "${paiDir}" 2>&1`,
       120000
     );
 
@@ -536,13 +551,13 @@ export async function runRepository(
       // If clone fails (dir not empty), try to init and pull
       await emit({ event: "progress", step: "repository", percent: 50, detail: "Directory exists, trying alternative approach..." });
 
-      const initResult = tryExec(`cd "${paiDir}" && git init && git remote add origin https://github.com/danielmiessler/PAI.git && git fetch origin && git checkout -b main origin/main 2>&1`, 120000);
+      const initResult = tryExec(`cd "${paiDir}" && git init && git remote add origin "${resolved.url}" && git fetch origin && git checkout -b main origin/main 2>&1`, 120000);
       if (initResult !== null) {
         await emit({ event: "message", content: "PAI repository initialized and synced." });
       } else {
         await emit({
           event: "message",
-          content: "Could not clone PAI repo automatically. You can clone it manually later: git clone https://github.com/danielmiessler/PAI.git ~/.claude",
+          content: `Could not clone PAI repo automatically. You can clone it manually later: git clone ${resolved.url} ${paiDir}`,
         });
       }
     }

--- a/Releases/v4.0.3+/.claude/PAI-Install/engine/config-gen.ts
+++ b/Releases/v4.0.3+/.claude/PAI-Install/engine/config-gen.ts
@@ -8,6 +8,7 @@
 
 import type { PAIConfig } from "./types";
 import { DEFAULT_VOICES, PAI_VERSION, ALGORITHM_VERSION } from "./types";
+import { resolveRepoUrl } from "./repo-url";
 
 /**
  * Generate a minimal fallback settings.json from installer-collected data.
@@ -57,7 +58,7 @@ export function generateSettingsJson(config: PAIConfig): Record<string, any> {
     },
 
     pai: {
-      repoUrl: "https://github.com/danielmiessler/PAI",
+      repoUrl: resolveRepoUrl(config.paiDir).url,
       version: PAI_VERSION,
       algorithmVersion: ALGORITHM_VERSION,
     },

--- a/Releases/v4.0.3+/.claude/PAI-Install/engine/repo-url.ts
+++ b/Releases/v4.0.3+/.claude/PAI-Install/engine/repo-url.ts
@@ -1,0 +1,59 @@
+/**
+ * PAI Installer v4.0 — Repo URL Resolution (GitHub #115)
+ *
+ * Priority (first match wins):
+ *   1. PAI_REPO_URL env var (set by install.sh --repo-url= or ambient env)
+ *   2. Existing `origin` remote at <paiDir>/.git (fork-remote preservation)
+ *   3. DEFAULT_PAI_REPO_URL (upstream fallback)
+ */
+
+import { execSync } from "child_process";
+import { existsSync } from "fs";
+import { join } from "path";
+
+export const DEFAULT_PAI_REPO_URL = "https://github.com/danielmiessler/Personal_AI_Infrastructure.git";
+
+type RepoUrlSource = "env" | "remote" | "default";
+
+export interface ResolvedRepoUrl {
+  url: string;
+  source: RepoUrlSource;
+  sourceLabel: string;
+}
+
+const SOURCE_LABELS: Record<RepoUrlSource, string> = {
+  env: "PAI_REPO_URL env var",
+  remote: "existing origin remote",
+  default: "upstream default",
+};
+
+export function resolveRepoUrl(paiDir?: string): ResolvedRepoUrl {
+  const envUrl = (process.env.PAI_REPO_URL || "").trim();
+  if (envUrl) {
+    return { url: envUrl, source: "env", sourceLabel: SOURCE_LABELS.env };
+  }
+
+  if (paiDir) {
+    const existingRemote = readOriginRemote(paiDir);
+    if (existingRemote) {
+      return { url: existingRemote, source: "remote", sourceLabel: SOURCE_LABELS.remote };
+    }
+  }
+
+  return { url: DEFAULT_PAI_REPO_URL, source: "default", sourceLabel: SOURCE_LABELS.default };
+}
+
+export function readOriginRemote(paiDir: string): string | null {
+  if (!existsSync(join(paiDir, ".git"))) return null;
+
+  try {
+    // 5s timeout guards against hangs on corrupted repos.
+    const raw = execSync(
+      `git -C "${paiDir}" remote get-url origin 2>/dev/null`,
+      { encoding: "utf-8", timeout: 5000 }
+    ).trim();
+    return raw || null;
+  } catch {
+    return null;
+  }
+}

--- a/Releases/v4.0.3+/.claude/PAI-Install/install.sh
+++ b/Releases/v4.0.3+/.claude/PAI-Install/install.sh
@@ -52,10 +52,24 @@ echo -e "           ${NAVY}████${RESET}        ${BLUE}████${RESE
 echo -e "           ${NAVY}████${RESET}        ${BLUE}████${RESET}${LIGHT_BLUE}████${RESET}   ${SEP}"
 echo ""
 echo ""
-echo -e "                       ${STEEL}→${RESET} ${BLUE}github.com/danielmiessler/PAI${RESET}"
+echo -e "                       ${STEEL}→${RESET} ${BLUE}danielmiessler/Personal_AI_Infrastructure${RESET}"
 echo ""
 echo -e "${STEEL}┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛${RESET}"
 echo ""
+
+# ─── Parse CLI Flags ──────────────────────────────────────
+# --repo-url=<git-url> lets fork installs override the clone source
+# (GitHub #115). PAI_REPO_URL from ambient env is honored as-is.
+for arg in "$@"; do
+  case "$arg" in
+    --repo-url=*)
+      PAI_REPO_URL="${arg#--repo-url=}"
+      ;;
+  esac
+done
+if [ -n "${PAI_REPO_URL:-}" ]; then
+  export PAI_REPO_URL
+fi
 
 # ─── Resolve Script Directory ─────────────────────────────
 # Follow symlinks so install.sh works from ~/.claude/ symlink


### PR DESCRIPTION
## Summary

Closes #115. The v4.0.3+ installer's `runRepository()` hardcoded `https://github.com/danielmiessler/PAI.git` at three sites, so forks could not bootstrap a new machine from their own remote — every fresh install or init-fallback cloned upstream regardless. This PR plumbs a configurable clone URL with three equivalent transports and preserves existing fork remotes across re-installs.

**Scope stayed narrow** — the three bullet points from #115's own "Suggested fixes" section:

1. **Configurable clone URL** via a new `engine/repo-url.ts` module that resolves `PAI_REPO_URL` → existing `origin` remote → upstream default (first match wins).
2. **Fork-remote preservation** — when `~/.claude/.git/` already has an `origin` configured, the installer detects it and reuses that URL for clone/init operations instead of clobbering with upstream.
3. **Documented fork-mode install** in the installer README.

**Explicitly out of scope** — did NOT touch `~/.claude/skills/` vs `~/.pai/skills/` (#110), installer-mirror rewrites, upstream Claude Code feature requests, or any state plumbing through the CLI/Web/Electron frontends. The env-var transport was chosen specifically to avoid threading a new field through five frontier surfaces.

## What changed

| File | Change |
|---|---|
| `engine/repo-url.ts` (new, 60 lines) | `DEFAULT_PAI_REPO_URL` constant + `resolveRepoUrl(paiDir?)` + `readOriginRemote(paiDir)` shared helper. Priority order: env → remote → default. Returns `{ url, source, sourceLabel }` so consumers never re-derive labels |
| `engine/actions.ts` | Imports `resolveRepoUrl`, `readOriginRemote`. Fresh-install and init-fallback paths use `resolved.url`. Upgrade path now logs which `origin` it's pulling from (observability for fork users) |
| `engine/config-gen.ts` | `pai.repoUrl` field in generated settings.json now uses `resolveRepoUrl(config.paiDir).url` instead of a hardcoded literal — fixes a phantom field that had been writing stale data to every install |
| `install.sh` | Parses `--repo-url=<git-url>` CLI flag, exports as `PAI_REPO_URL` before `exec bun run`. Also honors ambient `PAI_REPO_URL` env var |
| `cli/display.ts` | Banner text updated to canonical upstream name (see "Upstream URL correction" below) |
| `README.md` | New "Installing from a Fork" section documenting all three transports + existing-remote preservation. Pre-existing attribution links updated to canonical name. Issue link corrected to \`virtualian/pai/issues/115\` |

**Net diff:** 6 files, +122 / −9.

## Upstream URL correction (mid-task discovery)

While verifying the final diff, noticed that the existing hardcoded URL (`danielmiessler/PAI.git`) was in fact **stale** — Daniel's canonical repo is `danielmiessler/Personal_AI_Infrastructure`. GitHub's auto-rename redirect has been masking the drift: `git clone https://github.com/danielmiessler/PAI.git` still succeeds (silently redirects), so no install has ever failed. Verified empirically:

\`\`\`
$ git ls-remote https://github.com/danielmiessler/PAI.git HEAD
dc05fe9a10786bc77f1d0ad82e7d8cf23ada93d3  HEAD

$ git ls-remote https://github.com/danielmiessler/Personal_AI_Infrastructure.git HEAD
dc05fe9a10786bc77f1d0ad82e7d8cf23ada93d3  HEAD  # identical

$ curl -sIL -o /dev/null -w '%{url_effective}\n' https://github.com/danielmiessler/PAI
https://github.com/danielmiessler/Personal_AI_Infrastructure
\`\`\`

This PR **corrects the default** to the canonical name and updates the four pre-existing stale references found across the tree (2 in README, 1 in `install.sh` banner, 1 in `cli/display.ts` banner). The correction is in-scope because this PR is actively touching `DEFAULT_PAI_REPO_URL` — leaving it stale while fixing everything around it would be knowingly wrong.

**Banner width constraint:** the 68-column banner box could not fit the 52-char full URL (\`github.com/danielmiessler/Personal_AI_Infrastructure\`). Dropped the \`github.com/\` prefix, keeping \`danielmiessler/Personal_AI_Infrastructure\` (41 chars) — GitHub's \`user/repo\` shorthand is universally understood, and this preserves the original banner alignment with 2 columns of slack.

## Key decisions

| # | Decision | Why |
|---|---|---|
| D1 | Env var as transport, not state field | Avoids plumbing a new field through `install.sh → main.ts → cli/index.ts → InstallState → runRepository` (5 frontier surfaces). Env vars are the right tool when a value needs to cross many process/module boundaries without being part of anyone's contract |
| D2 | New `engine/repo-url.ts` module, not helper in `engine/actions.ts` | Keeps `resolveRepoUrl` importable from both `actions.ts` and `config-gen.ts` without creating a cycle back through `actions.ts`'s heavier dependency graph |
| D3 | `readOriginRemote` exported as shared helper | Both the upgrade-path observability log and the fresh-install resolution need to read origin; exporting it from one place avoids duplicating the same `git remote get-url` inline |
| D4 | `sourceLabel` stored on `ResolvedRepoUrl`, not re-derived by consumers | Prevents drift if new sources are added later. Caught by the `/simplify` quality review — `actions.ts` originally had a 4-line switch that duplicated knowledge the `repo-url` module already had |
| D5 | Correct upstream default in-branch, not as follow-up | This PR already touches `DEFAULT_PAI_REPO_URL`; fixing it to the canonical name is one character of extra effort. Leaving it stale would commit the same bug I just discovered |
| D6 | Banner drops \`github.com/\` prefix, not full URL | 68-column box cannot fit 52-char URL; full URL would overflow the banner's corner characters. \`user/repo\` shorthand is universally understood and preserves alignment |

## Scope excluded (intentional)

- **No `~/.claude/skills/` runtime read-path changes** — that's #110, filed as a peer issue with explicit architectural recommendation (Option B: per-pack symlinks)
- **No `engine/exec.ts` refactor** — `/simplify` review correctly noted that `tryExec` is now hand-rolled in 3 places (`actions.ts:148`, `detect.ts:13`, formerly in `repo-url.ts`). Promoting it to a shared module is legitimate debt but outside #115's scope. This PR uses `engine/repo-url.ts`'s own exported `readOriginRemote` as the shared surface for the narrow case that matters here, leaving the broader `tryExec` situation alone
- **No state plumbing** — `InstallState.collected.repoUrl` was considered and rejected. Env var transport keeps the change contained to `runRepository` + `config-gen.ts`
- **No CI/CD / install.sh headless-mode changes** — ambient `PAI_REPO_URL` env var works uniformly across CLI, web, and GUI modes
- **No changes to runtime installation at `~/.claude/`** — repo-only edits per the two-root separation plan

## Verification

**Behavioral tests** — 12 cases passing on `resolveRepoUrl` and `readOriginRemote`:
- Default without \`paiDir\`
- Env var wins over no-paiDir
- Empty env var falls through to default
- Whitespace-only env var falls through
- Existing \`origin\` remote preserved when \`paiDir/.git\` exists
- Env var still wins over existing remote
- \`readOriginRemote\` on non-git dir returns \`null\`
- \`resolveRepoUrl\` on non-git dir returns default
- \`sourceLabel\` populated correctly for all three sources
- \`readOriginRemote\` direct export functions standalone

**Upstream URL verification:**
- \`git ls-remote https://github.com/danielmiessler/Personal_AI_Infrastructure.git HEAD\` — live network probe, returns valid 40-char SHA with \`HEAD\` ref
- Matches the SHA returned by the old (redirected) URL, confirming semantic equivalence

**Shell syntax:** \`bash -n install.sh\` — OK after banner edit

**Import smoke test:** \`bun run\` imports all three modified engine modules (\`repo-url\`, \`types\`, \`config-gen\`) — clean parse

**Final grep sweep:** \`grep -F 'danielmiessler/PAI' Releases/v4.0.3+/.claude/PAI-Install/\` — **zero hits** (fixed-string search across the whole installer tree)

## /simplify review outcomes

Three review agents ran in parallel (reuse, quality, efficiency). Efficiency was clean; reuse and quality together surfaced 7 real findings, 6 of which were fixed in-PR before commit:

1. Dead \`PASSTHROUGH_ARGS\` array in \`install.sh\` — deleted
2. Phantom \`PAIConfig.repoUrl?\` field (nothing wrote to it) — removed; \`generateSettingsJson\` calls \`resolveRepoUrl\` directly
3. Duplicate priority-order comment in \`actions.ts\` (already documented in \`repo-url.ts\`) — deleted
4. Leaky label strings in \`actions.ts\` — moved to \`ResolvedRepoUrl.sourceLabel\`
5. Unused \`RepoUrlSource\` export — made internal
6. Duplicate inline \`git remote get-url\` in upgrade path — now uses exported \`readOriginRemote\`
7. \`tryExec\` debt (3 copies across codebase) — **deferred** as pre-existing debt outside #115 scope

## Test plan

- [x] Behavioral test suite passes (12/12) — covers all priority paths, edge cases, and \`sourceLabel\` population
- [x] Live \`git ls-remote\` against canonical upstream URL succeeds
- [x] \`bash -n install.sh\` passes syntax check
- [x] \`bun run\` imports all modified engine modules cleanly
- [x] \`grep -F 'danielmiessler/PAI'\` returns zero hits across \`PAI-Install/\`
- [x] \`/simplify\` multi-agent review run; actionable findings fixed before commit
- [ ] **Manual smoke test post-merge (fresh-install path):** on a clean VM, \`PAI_REPO_URL=https://github.com/YOUR_FORK/pai.git bash install.sh\` — confirm installer messages show "Using repo URL from PAI_REPO_URL env var" and \`~/.claude/.git/config\` reports the fork as origin
- [ ] **Manual smoke test post-merge (fork-remote preservation):** on a machine with an existing \`~/.claude/\` checked out from a fork, re-run \`install.sh\` without any env var — confirm installer messages show "Using repo URL from existing origin remote" and the fork URL, not upstream
- [ ] **Manual smoke test post-merge (default fallback):** on a clean VM with no env var, run \`install.sh\` — confirm it clones \`Personal_AI_Infrastructure\` (not the old \`PAI\` name) and the banner displays \`danielmiessler/Personal_AI_Infrastructure\`
- [ ] **Visual check:** CLI banner alignment after running \`--mode cli\` — the box-drawing characters should still align with the URL text (2-column slack expected)

## Related

- Closes #115
- Peer issues from same investigation: #108 (\`.claude/PAI/\` mirror), #110 (skills runtime read path)
- Umbrella: #98 (two-root separation)
- Plans: \`Plans/2026-04-14-two-root-separation-followups.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)