### PR TITLE
Commit three untracked Plans docs for two-root separation cluster

### DIFF
--- a/Plans/2026-04-14-110-mirror-source-investigation.md
+++ b/Plans/2026-04-14-110-mirror-source-investigation.md
@@ -1,0 +1,189 @@
+# #110 Mirror-Source Investigation
+
+**Date:** 2026-04-14
+**Branch context:** `main` after PR #120 (#115 fix) merge
+**Purpose:** Answer the question left open by the #110 investigation-session comment: "the 178 MB structural mirror between `~/.claude/skills/` and `~/.pai/skills/` is not maintained by the installer's current code — whoever implements Option B needs to figure out what creates it."
+
+## TL;DR
+
+**Path A is confirmed: the mirror is static.** No active code path in `Releases/v4.0.3+/.claude/` writes to either `~/.claude/skills/` or `~/.pai/skills/`. The installer's "paiDir" variable is semantically `~/.claude/` (it defaults to `join(homedir(), ".claude")` and every consumer treats it that way) — it never touches `~/.pai/` at all. Current content of `~/.pai/skills/` was populated by an out-of-installer mechanism (likely a Packs-apply script or manual migration) and has not been updated since **Apr 7 2026**, one week before this investigation.
+
+**Implication for Option B:** the implementation does not need to patch a recurring creator. It needs to (a) add symlink logic to the installer for future fresh installs and (b) ship a one-shot converter script for existing machines.
+
+## Evidence
+
+### 1. Installer's `paiDir` variable = `~/.claude/`, not `~/.pai/`
+
+`Releases/v4.0.3+/.claude/PAI-Install/engine/actions.ts:503`:
+
+```ts
+const paiDir = state.detection?.paiDir || join(homedir(), ".claude");
+```
+
+Confirmed by 8 consumers in the same file:
+- `actions.ts:209-210` legacy migration paths (`paiDir/skills/PAI/USER`, `paiDir/skills/CORE/USER`)
+- `actions.ts:687-688` skill count for banner (`paiDir/skills/<pack>/SKILL.md`)
+- `actions.ts:694` skills dir path
+- `detect.ts:93` existing-install signature check (`paiDir/skills/PAI/SKILL.md`)
+- `validate.ts:110` skill path validation
+
+The variable **name** is misleading — despite being called `paiDir`, it resolves to `~/.claude/` and all consumers treat it as the Claude-Code config root. This was flagged in #110's existing comment but the significance is now concrete: **the installer has no code path that can touch `~/.pai/skills/`**.
+
+### 2. No skill-directory writes in installer code
+
+Exhaustive grep of `Releases/v4.0.3+/.claude/PAI-Install/engine/` for write operations involving `skills`:
+
+| Pattern | Hits |
+|---|---|
+| `cpSync.*skills` | 0 |
+| `symlinkSync.*skills` | 0 |
+| `writeFileSync.*skills` | 0 |
+| `mkdirSync.*skills` | Only `requiredDirs` list in `runRepository` which creates empty `skills/` directory as a placeholder if missing |
+
+The only thing `runRepository` does to `~/.claude/skills/` is `mkdirSync` to ensure it exists. Actual skill *content* in `~/.claude/skills/` arrives via the git clone step (`git clone danielmiessler/Personal_AI_Infrastructure.git ~/.claude`) — the upstream repo has `skills/` at root, so git clone drops it there directly.
+
+### 3. `~/.pai/skills/` mtimes prove the tree is static
+
+```
+Apr  7 21:05:06 2026  /Users/ianmarr/.pai/skills/Learning
+Apr  7 21:05:06 2026  /Users/ianmarr/.pai/skills/Research
+Mar 19 13:33:56 2026  /Users/ianmarr/.pai/skills/Agents
+Mar 19 13:37:42 2026  /Users/ianmarr/.pai/skills/ContentAnalysis
+Mar 19 13:39:46 2026  /Users/ianmarr/.pai/skills/Investigation
+Mar 19 13:41:04 2026  /Users/ianmarr/.pai/skills/Media
+Mar 19 13:44:16 2026  /Users/ianmarr/.pai/skills/Scraping
+Mar 19 13:45:46 2026  /Users/ianmarr/.pai/skills/Security
+Mar 19 13:46:52 2026  /Users/ianmarr/.pai/skills/Telos
+Mar 19 13:48:34 2026  /Users/ianmarr/.pai/skills/Thinking
+Mar 19 13:50:08 2026  /Users/ianmarr/.pai/skills/USMetrics
+Mar 19 13:54:45 2026  /Users/ianmarr/.pai/skills/Diataxis-Documentation
+Mar 22 16:41:02 2026  /Users/ianmarr/.pai/skills/Utilities
+Mar 26 16:54:45 2026  /Users/ianmarr/.pai/skills/find-skills
+```
+
+Pattern analysis:
+- **Mar 19 13:33-13:54** — initial population batch (12 packs created in ~20 minutes, consistent with a one-shot copy script)
+- **Mar 22 / Mar 26** — 2 individual updates (Utilities edited; find-skills added)
+- **Apr 7 21:05** — 2 simultaneous updates (Learning + Research — a coordinated edit batch)
+- **No updates since Apr 7 21:05** — 7 days of no activity on any pack
+
+Crucially, **#101 (two-root separation) merged on 2026-04-12** — *after* most of this mtime activity. So `~/.pai/skills/` pre-dates the two-root separation, meaning #101 did not create the canonical tree; something earlier did. #101 ratified the CODE-root location in the architecture but didn't install or populate it.
+
+### 4. Fork `Packs/` directory is the likely upstream source
+
+```
+/Users/ianmarr/projects/pai/Packs/
+├── Agents
+├── ContentAnalysis
+├── ContextSearch            ← present in Packs, absent in ~/.pai/skills/ (not yet applied?)
+├── Investigation
+├── Learning
+├── Media
+├── pai-diataxis-documentation-skill  ← name-mapped to ~/.pai/skills/Diataxis-Documentation
+├── Research
+├── Scraping
+├── Security
+├── Telos
+├── Thinking
+├── USMetrics
+└── Utilities
+```
+
+This pack-set roughly matches `~/.pai/skills/` (with a rename on Diataxis and one un-applied pack, `ContextSearch`). There is almost certainly an "apply pack" script somewhere in `Tools/` or `Packs/*/src/Workflows/Apply.md` that copies `Packs/<Name>/src/` → `~/.pai/skills/<Name>/`. I did not trace it fully in this investigation because the question was "what maintains the mirror" and the answer is "nothing in the installer" — the Packs apply step is a separate concern.
+
+### 5. Runtime read paths are split between the two trees
+
+`hooks/lib/paths.ts`:
+
+```ts
+// Line 87: Get the skills directory (lives in PAI code root)
+export function skillsDir(): string {
+  return codePath('skills');   // = ~/.pai/skills/
+}
+```
+
+- **PAI-internal hooks/tools** that use `codePath('skills')` read from `~/.pai/skills/` (the stale tree)
+- **Claude Code harness** reads from `~/.claude/skills/` (hardcoded, as documented in #110)
+- **Session-start context injection** (if any) needs to be audited — if it uses `codePath` it's reading stale content
+
+This is a *real* correctness issue: any PAI tool that enumerates skills today is seeing Mar 19 content while Claude Code is seeing Apr 7 content. Two separate versions of the same skill set are simultaneously "live."
+
+## Implication for #110 Option B implementation
+
+### Option B variants
+
+The #110 issue proposed Option B as "replace each PAI-owned subdirectory of `~/.claude/skills/` with a symlink to `~/.pai/skills/<PackName>`." This framing has a chicken-and-egg problem: it assumes `~/.pai/skills/` is the canonical source, but the current installer doesn't populate it — so on a fresh install, `~/.pai/skills/` would be empty and the symlinks would point at nothing.
+
+Three concrete implementation plans, ordered by blast radius (lowest first):
+
+#### B-Plan-1 — "Copy-then-symlink" (RECOMMENDED for minimum disruption)
+
+**Flow:**
+1. Installer clones upstream → `~/.claude/` (unchanged behavior)
+2. **New step:** after clone, for each directory in `~/.claude/skills/`:
+   - If the pack is PAI-owned (detected by membership check — see below): `cpSync` it to `~/.pai/skills/<pack>/`, then delete `~/.claude/skills/<pack>/`, then create `symlinkSync(~/.pai/skills/<pack>, ~/.claude/skills/<pack>)`
+   - If the pack is third-party (e.g. `tts-tutor-skill` — not present in `~/.pai/skills/` AND not shipped in upstream): leave alone
+
+**PAI-ownership detection:** the simplest heuristic is "anything shipped in the upstream PAI repo is PAI-owned." After git clone, the directories under `~/.claude/skills/` are exactly the upstream-shipped ones. Any third-party pack installed later (e.g. via Claude Code marketplace) lands after install and won't be touched by the installer's symlink step. So the rule becomes: **"At install time, symlink-ify every directory currently in `~/.claude/skills/`; leave anything added later alone."**
+
+**Pros:**
+- Minimum disruption to installer architecture
+- Installer still clones to `~/.claude/` (no clone-target refactor)
+- Existing machines can run a one-shot converter script that uses the same logic
+- The "PAI-owned" set is determined by the upstream content, not a manifest file
+
+**Cons:**
+- `~/.pai/skills/` becomes a *derivative* of `~/.claude/skills/` (written by the installer after clone), not a canonical source in its own right. This subtly contradicts the #101 framing of `~/.pai/skills/` as the "canonical" location — but since #101 didn't actually implement the canonicalness, this is more a matter of semantic tidiness than regression
+- Drift risk persists during the symlink step: if the clone completes but the cpSync fails, the system is in a half-state
+
+#### B-Plan-2 — "Clone-to-PAI-root" (cleanest, biggest refactor)
+
+**Flow:**
+1. Installer clones upstream → `~/.pai/` directly (**clone target changes**)
+2. `~/.pai/skills/` is populated by git clone (no extra step)
+3. **New step:** installer creates `~/.claude/skills/` as a directory containing symlinks pointing at each `~/.pai/skills/<pack>`
+4. `~/.claude/` continues to host settings.json, hooks, MEMORY (config root) — but these come from the same clone via a sub-copy step
+
+**Pros:**
+- Architecturally pure: `~/.pai/` is the CODE root and canonical source; `~/.claude/` is a thin config layer with symlinks
+- Matches #101's stated intent exactly
+- No cpSync needed during install — git clone is the only content-write operation
+
+**Cons:**
+- **Changes the clone target**, which touches every `paiDir` reference in the installer (~20 sites). Extended/Advanced effort.
+- Every file in the upstream repo root that was "supposed to land in `~/.claude/`" (settings.json, hooks/, MEMORY/, CLAUDE.md, etc.) now has to be explicitly copied from `~/.pai/<file>` to `~/.claude/<file>`. This is a non-trivial amount of new cpSync logic.
+- Bigger blast radius means higher chance of a regression in fresh-install success rate
+
+#### B-Plan-0 — "Option D and wait" (lowest effort, longest timeline)
+
+Punt to the upstream feature request #110 identified as Option D: get Claude Code to add a `skillsPaths: [...]` field to `settings.json` schema. Once that lands, set `skillsPaths: ["~/.pai/skills"]` and the whole symlink problem disappears.
+
+**Pros:** zero symlinks, zero installer changes, clean architecture.
+**Cons:** depends on Anthropic accepting the feature request. Timeline unknown. PAI can't ship it unilaterally.
+
+Not mutually exclusive with B-Plan-1 — we could ship B-Plan-1 now and remove the symlinks later if Option D lands.
+
+## Open questions for next session
+
+1. **Which variant?** My recommendation is **B-Plan-1** (ship now, safest, reversible). B-Plan-2 is architecturally cleaner but the installer refactor risk is real. B-Plan-0 is a parallel track that doesn't block B-Plan-1.
+
+2. **Conflict resolution on existing installs:** the current `~/.claude/skills/` and `~/.pai/skills/` have drifted — `~/.claude/skills/Learning/` is Apr 7 content and `~/.pai/skills/Learning/` is also Apr 7 (matched timestamp); most other packs are Mar 19 in `~/.pai/` but unknown date in `~/.claude/`. A one-shot converter script has to decide which tree's content wins on conflict. **Recommendation: `~/.claude/skills/` wins** because that's the tree the Claude Code harness actually reads and the one the installer populates from fresh clones. Document this; log any conflicts encountered.
+
+3. **Session-start context injection audit:** does any PAI hook or tool use `codePath('skills')` to read content at session start? If yes, those reads are currently hitting the stale `~/.pai/skills/` tree. B-Plan-1 fixes this automatically (the tree becomes fresh after install). But worth auditing explicitly to confirm no other code path is reading stale skills.
+
+4. **How does `Packs/` → `~/.pai/skills/` get applied today?** I didn't trace this. Not required for #110 implementation (B-Plan-1 doesn't care), but worth knowing for completeness. Likely lives in `Tools/` or in `Packs/*/src/Workflows/Apply.md` — either a Pack-apply script or a workflow skill that ships a pack to runtime. This mechanism is what made `~/.pai/skills/Diataxis-Documentation` exist despite the different source name `pai-diataxis-documentation-skill` — there's rename logic somewhere.
+
+5. **Upstream repo layout:** does `danielmiessler/Personal_AI_Infrastructure` have `skills/` at its root? If yes, B-Plan-1 works as designed. If no, the clone mechanism is different and needs to be understood first. One way to verify: shallow clone to a temp dir and list root.
+
+## Status
+
+- ✅ Mirror source question answered: **Path A, static mirror, no installer writes**
+- ✅ Three implementation variants scoped with tradeoffs
+- ✅ B-Plan-1 recommended as minimum-disruption
+- ⏸️ **Stopping here.** No implementation work started. Next session picks up with open questions 1-5 resolved, then writes a design PRD and starts BUILD.
+
+## Related
+
+- Blocks: none
+- Related: #110 (issue), #115 (merged as PR #120), #101 (two-root separation ratification), #108 (`.claude/PAI/` mirror — same pattern, different tree), #114 (433+ stale `~/.claude/` doc refs)
+- Referenced from: this should probably be linked from #110 as an investigation update once it lands in the repo

--- a/Plans/2026-04-14-two-root-separation-followups.md
+++ b/Plans/2026-04-14-two-root-separation-followups.md
@@ -1,0 +1,238 @@
+# Two-Root Separation Followups — Planning Doc
+
+> **Date:** 2026-04-14
+> **Status:** Investigation complete. Implementation not started.
+> **Scope:** Repo-only edits. No runtime modifications. No migration shim.
+> **Audience:** Future Claude conversations picking up issues #108, #109, #110, #115 individually.
+
+---
+
+## Why this doc exists
+
+The investigation that filed issues #108, #109, #110, and #115 surfaced findings, decisions, and constraints that don't fit cleanly into any single issue. Rather than spread context across long conversations, this doc consolidates the planning state so that each issue can be picked up in a fresh conversation by reading: (a) the issue body, (b) the issue's update comments, (c) this doc.
+
+If you are a fresh conversation handed one of these issues — read this doc first, then read the issue, then proceed.
+
+---
+
+## The problem in one paragraph
+
+PR #101 declared a two-root architecture (`CLAUDE_CONFIG_DIR=~/.claude/` for Claude Code harness state; `PAI_DIR=~/.pai/` for PAI's CODE root) and rewrote 749 path references across 185 files to match. The declaration was string-level only — the runtime loaders, the installer, the Learning skill workflows, and Claude Code's own skill scanner did not change to match. Three subsystems still operate on the pre-separation paths:
+
+1. **`~/.claude/PAI/` mirror tree** still exists alongside `~/.pai/PAI/` with content drift; canonical files contain residual `~/.claude/PAI/` strings; `RebuildPAI.ts:16` has hardcoded `~/.claude/PAI` in executable code (#108)
+2. **Learning skill `Apply.md`** points at a phantom AISTEERINGRULES path, reads from the stale `~/.claude/PAI/` Algorithm tree, and labels Claude Code per-cwd auto-memory as "PAI memory directory" (#109)
+3. **Claude Code's skills loader** is hardcoded to scan `~/.claude/skills/`; PAI cannot redirect it without symlinks, an `--add-dir` launch flag, or an upstream Claude Code feature (#110)
+
+A fourth issue — the installer hardcodes `danielmiessler/PAI` as the clone source so fork edits never reach runtime via reinstall (#115) — was discovered while investigating regression risk for #108–#110 and is a contributing cause of all three.
+
+---
+
+## The 5 issues at a glance
+
+| Issue | Title | Tonight's scope | Blocking decisions |
+|---|---|---|---|
+| **#98** | Separate PAI installation from CC config: CLAUDE_CONFIG_DIR + PAI_DIR | Parent — closes when children land | None |
+| **#108** | Stale `~/.claude/PAI/` mirror + residual strings + ambiguous CLAUDE.md Algorithm load | **In scope** — surgical string edits in repo only | None — surgical-only decided (see below) |
+| **#109** | Learning skill writes feedback to Claude Code auto-memory mislabeled as "PAI memory directory" + reads from stale tree + phantom AISTEERINGRULES path | **In scope** — Apply.md edits in repo only | **Path A vs Path B for feedback memory home** (see below) |
+| **#110** | Skills separation is documentation-only; harness reads `~/.claude/skills/`, not `~/.pai/skills/` | **Deferred** — needs design phase first | Ownership manifest; Option B vs D vs combined; coordination with #115 |
+| **#115** | Installer hardcodes upstream `danielmiessler/PAI` clone URL; fork edits never reach runtime via reinstall | **Deferred** — needs design phase first | None — but blocks the practical impact of #108 and #110 fixes for fork users |
+
+---
+
+## Tonight's scope decision
+
+**Implement #108 + #109 only. Defer #110 and #115.**
+
+Rationale:
+
+- **#108 + #109 are surgical string edits** with clear evidence and well-defined scope. Both can be expressed as small focused PRs against the repo.
+- **#110 needs a design phase first** — choosing Option B (per-pack symlinks) vs Option D (upstream Claude Code `skillsPaths` feature request) vs a combined approach, and building an ownership manifest that distinguishes PAI-pack-owned skill subdirectories from third-party / user-installed ones (e.g. `tts-tutor-skill`).
+- **#115 is independent of #108 + #109** but has its own design surface (env var? settings.json field? CLI flag? auto-detect existing fork remote?) that's worth its own thread.
+- **#110 and #115 are coupled** — fixing #110 in a fork won't reach users until #115 is also fixed, because the fork-side installer changes never get cloned into a user's `~/.claude/`.
+
+---
+
+## Constraints for the implementation work
+
+These constraints were set by the user during the investigation session and apply to anyone picking up #108 or #109:
+
+1. **Repo-only edits.** No modifications to runtime (`~/.claude/` or `~/.pai/`). The runtime is being managed separately and is currently in flux on this machine (see "Runtime state on this machine" below).
+2. **No migration shim.** The user explicitly does not want a separate migration script. Edits go in the repo; how they reach runtime is a separate later problem.
+3. **No commits without explicit user approval.** Per MARR `prj-version-control-standard.md` and the AI Steering Rules. Working-tree edits are fine; `git commit`, `git push`, and `gh pr create` require an explicit go from the user, not implicit consent from the issue being filed.
+4. **Branch strategy.** Use a feature branch per issue (or paired-issue branch). Suggested names: `fix/108-residual-claude-pai-paths`, `fix/109-learning-skill-feedback-paths`. Confirm with user before creating.
+
+---
+
+## Open design decisions
+
+### #109 — Path A vs Path B for feedback memory home
+
+The Apply.md mislabel fix forks based on this design call. **Decision needed before any edits to Apply.md:70 or Apply.md:82.**
+
+| | **Path A** | **Path B** |
+|---|---|---|
+| Approach | Keep using Claude Code per-cwd auto-memory at `~/.claude/projects/<cwd-slug>/memory/`. Rename "PAI memory directory" label in Apply.md to "Claude Code project memory". Document the per-cwd silo as intended behavior. | Build a PAI-native feedback directory at `~/.pai/MEMORY/FEEDBACK/`. Update Apply.md to point there. Migrate existing files. May require loader code in PAI hooks. May require changes to /Learn synthesis workflow. |
+| Effort | ~30 min, single small PR | Several hours, multiple touch points |
+| Per-cwd silo | Yes (documented as intended) | No (global feedback) |
+| Coupling to Claude Code | High | None |
+| Architectural cleanliness | Compromise | Correct |
+| Risk | Low | Medium |
+| Resolves #97? | No | Partially |
+
+**Recommendation framing:** If the priority is "close the bug surface fast" → A. If the priority is "finish the PAI memory architecture properly" → B. They are not stepping stones; switching from A to B later requires undoing the documentation work.
+
+**Independent of A vs B:** Apply.md:68 (Algorithm spec read path) and Apply.md:69 (phantom AISTEERINGRULES path) can be fixed regardless. Only Apply.md:70 and Apply.md:82 depend on this decision.
+
+### #110 — Skills separation strategy
+
+Four options documented in the issue body. **Recommendation: Option B (per-pack symlinks) for short-term + Option D (upstream Claude Code `skillsPaths` feature request) for long-term.** Decision deferred until separate design phase.
+
+### #115 — Installer URL configurability
+
+Three suggested approaches in the issue body. **No recommendation yet.** Decision deferred.
+
+---
+
+## Per-issue work plans
+
+### #108 — Implementation plan
+
+**Files to edit (all in repo):**
+
+| File | Change |
+|---|---|
+| `Releases/v4.0.3+/.claude/PAI/Algorithm/v3.7.0.md` lines 38, 136, 203, 424 | Replace 4 residual `~/.claude/PAI/` references with `${PAI_DIR}/PAI/` or equivalent |
+| `Releases/v4.0.3+/.claude/PAI/Tools/RebuildPAI.ts:16` | Replace `const PAI_DIR = join(HOME, ".claude/PAI");` with `PAI_DIR` env var resolution |
+| `Releases/v4.0.3+/.claude/PAI/Tools/Notify.ts` (header comment) | Update doc-comment path |
+| `Releases/v4.0.3+/.claude/PAI/Tools/SecretScan.ts` (header comment) | Update doc-comment path |
+| `Releases/v4.0.3+/.claude/PAI/Tools/SessionProgress.ts` (header comment) | Update doc-comment path |
+| `Releases/v4.0.3+/.claude/PAI/Tools/LoadSkillConfig.ts` (header + doc) | Update doc-comment path |
+| `Releases/v4.0.3+/.claude/PAI/Tools/templates/LOCAL_PATCHES-TEMPLATE.md` | Update doc path examples |
+| `Releases/v4.0.3+/.claude/PAI/CLI.md` | Replace `~/.claude/PAI/Tools/algorithm.ts` reference |
+| `Releases/v4.0.3+/.claude/PAI/FLOWS.md` | Replace 4 `~/.claude/PAI/` references |
+| `Releases/v4.0.3+/.claude/PAI/DOCUMENTATIONINDEX.md` | Replace "All documentation files are in `~/.claude/PAI/`" line |
+
+**Critical: do NOT reconcile the 102-line Algorithm gap in this PR.** The repo's `v3.7.0.md` is 382 lines; runtime is 484 lines. Runtime contains rules sections (Directive Compliance Gate, Scope Gate hard-block, Target Declaration, Fast-Path Classifier) that the repo lacks. **This is a separate reconciliation problem with its own PR and its own discussion.** Do not bundle it.
+
+**CI guard to add (optional, but matches #105's pattern):** a check that no file inside `Releases/v4.0.3+/.claude/PAI/` (or wherever the canonical tree lives) contains a hardcoded `~/.claude/PAI` string.
+
+**Verification:**
+- `grep -rn '~/.claude/PAI' Releases/v4.0.3+/.claude/PAI/` should return zero results after the fix
+- `RebuildPAI.ts` should not contain the literal string `.claude/PAI` in executable code; only env-var references
+
+### #109 — Implementation plan
+
+**Files to edit (all in repo, ASSUMING Path A is chosen):**
+
+```
+Packs/Learning/src/Workflows/Apply.md                                lines 68, 69, 70, 82
+Releases/v4.0.3+/.claude/skills/Learning/Workflows/Apply.md          lines 68, 69, 70, 82
+```
+
+These two locations diverge by 4 bytes — determine which is the source-of-truth and how/whether they're kept in sync (might be a build step). The runtime version at `~/.pai/skills/Learning/Workflows/Apply.md` is 33-37 bytes ahead of both and is **explicitly out of scope** for this PR.
+
+**Specific line edits:**
+
+| Line | Current | Fixed (Path A) |
+|---|---|---|
+| 68 | `Read \`~/.claude/PAI/Algorithm/LATEST\`...` | `Read \`~/.pai/PAI/Algorithm/LATEST\`...` |
+| 69 | `Read \`~/.claude/AISTEERINGRULES.md\`` (phantom file) | `Read \`~/.pai/PAI/AISTEERINGRULES.md\`` |
+| 70 | `Read the PAI memory directory \`~/.claude/projects/*/memory/\`...` | `Read the Claude Code project memory directory \`~/.claude/projects/*/memory/\`...` |
+| 82 | `...written to the PAI memory directory.` | `...written to the Claude Code project memory directory (per-cwd silo by design — see #109).` |
+
+**If Path B is chosen instead**, lines 70 and 82 point at the new `~/.pai/MEMORY/FEEDBACK/` location, plus build the directory + loader + migration. Larger change.
+
+**Audit Check.md and Review.md** in the same workflow directory for the same pattern. The original investigation only verified Apply.md.
+
+**Verification:**
+- `grep -n '~/.claude/AISTEERINGRULES.md' Packs/Learning/` should return zero results
+- The phrase "PAI memory directory" should not appear in any Learning skill workflow file referring to a `~/.claude/projects/` path
+
+### #110 — Deferred work plan
+
+Not for tonight. When picked up:
+
+1. Read #110 + #115 fully — they are coupled
+2. Build an ownership manifest: enumerate each `~/.claude/skills/<dir>/` and classify as PAI-pack-owned (symlink target) vs third-party / user-installed (leave alone). On the investigation machine, `tts-tutor-skill` was identified as third-party (only existed in `~/.claude/skills/`, not in `~/.pai/skills/`)
+3. Decide ordering relative to #115
+4. Decide Option B (per-pack symlinks) vs Option B + Option D (symlinks now, upstream feature later)
+5. Design installer changes that create symlinks on first install and idempotently convert pre-existing dirs on upgrade
+6. (Optional) File upstream Claude Code feature request for `skillsPaths` settings.json field
+
+### #115 — Deferred work plan
+
+Not for tonight. When picked up:
+
+1. Decide override mechanism: env var (`PAI_REPO_URL`), settings.json field (`pai.repoUrl` already exists in `config-gen.ts` — just plumb it through to `runRepository`), CLI flag, or auto-detect existing remote
+2. Patch `engine/actions.ts:529` and `engine/actions.ts:539` to use the configured URL
+3. Patch the existing-install path at `engine/actions.ts:511` to read the existing remote rather than assuming upstream
+4. Document fork-mode install instructions
+5. Coordinate with #110 — both touch the installer
+
+---
+
+## Runtime state on this machine (as of 2026-04-14 ~01:00 BST)
+
+This is **machine-specific** and not relevant to anyone working from a fresh checkout — but matters for anyone trying to verify findings against the same machine:
+
+| Path | State |
+|---|---|
+| `~/.claude/PAI/` | **Deleted** (manual cleanup, backup at `~/backups/pai/claude-20260414-004729/PAI/`) |
+| `~/.claude/PAI-Install/` | **Deleted** (manual cleanup, backup at `~/backups/pai/claude-20260414-004729/PAI-Install/`) |
+| `~/.claude/CLAUDE.md` | **In active user editing** — last seen mid-transition (Algorithm v3.7.0 → v3.5.0, Notify.ts → inline curl). Do not touch from a Claude conversation. |
+| `~/.pai/PAI/AISTEERINGRULES.md` | **In active /Learn editing** — grew 6313 → 11926 b mid-investigation as /Learn appended new rules. Do not touch from a Claude conversation. |
+| `~/.pai/PAI/Algorithm/v3.7.0.md` | 484 lines, 40197 b — 102 lines ahead of repo (Directive Compliance Gate, Scope Gate hard-block, etc.) |
+| `~/.claude/skills/` | Untouched — 178 MB, 8392 files. Includes `tts-tutor-skill` which is third-party and only exists here, not in `~/.pai/skills/` |
+| `~/.pai/skills/` | Untouched — 178 MB, 8391 files. Canonical-by-#101-design but never read by Claude Code harness |
+| `~/.claude/.git/` | Does not exist — `~/.claude/` is not a git repo on this machine |
+| `~/.pai/.git/` | Does not exist — `~/.pai/` is not a git repo on this machine |
+
+**Implication:** The installer's `git pull origin main` code path at `engine/actions.ts:511` is unreachable on this machine (no `.git/`). The `git clone` path at line 529 would fail because `~/.claude/` is non-empty. The fallback init+fetch+checkout path at line 539 would attempt to overlay upstream files. None of these will run unless `install.sh` is explicitly invoked.
+
+**Most importantly:** the installer never touches `~/.pai/`. All runtime PAI content under `~/.pai/` is **regression-safe** from any installer invocation. The runtime drift between `~/.claude/skills/` and `~/.pai/skills/` (e.g. `tts-tutor-skill`) is therefore not maintained by the installer's current code — it predates this code path and was created by some other mechanism (likely a one-shot manual hand-migration during PR #101 rollout).
+
+---
+
+## Branch + PR strategy
+
+**Recommendation:** one branch per issue, two PRs.
+
+```
+git checkout -b fix/108-residual-claude-pai-paths
+# implement #108 surgical fixes
+# request user approval before commit + push + PR
+
+git checkout main
+git checkout -b fix/109-learning-skill-feedback-paths
+# implement #109 fixes (after user picks Path A vs B)
+# request user approval before commit + push + PR
+```
+
+Alternative: bundle as one PR. Simpler review but more entangled to revert. Decide with user before opening branches.
+
+**Per MARR `prj-version-control-standard.md`:** explicit approval required for every `git commit`, `git push`, and `gh pr create`. Working-tree edits are fine without approval.
+
+---
+
+## Fresh-conversation handoff notes
+
+If you are picking this up in a new conversation:
+
+1. **Read this doc first.** It captures decisions and constraints not in the issue bodies.
+2. **Then read the relevant issue and all its comments.** Pay attention to the most recent comments — they contain corrections and updates to the original issue body.
+3. **Verify file state before editing.** File line numbers cited in this doc and in the issues were accurate as of 2026-04-14. They may have shifted. Re-verify with `grep -n` before applying any edit.
+4. **Do not assume the runtime state.** This doc describes one specific machine's state. A fresh checkout will have a different state.
+5. **Do not commit without explicit approval.** The user has been clear about this. Working-tree edits and reading are fine; staging + committing requires a go.
+6. **Path A vs Path B (#109) is a USER decision.** Do not pick it autonomously. Surface it explicitly and wait for an answer.
+7. **The 102-line Algorithm gap is a separate problem.** Do not bundle it with #108's residual-string fix.
+8. **#110 and #115 are not in tonight's scope.** Refer to this doc's per-issue work plans for what they need before being picked up.
+
+---
+
+## Investigation artifacts (not needed for implementation, but useful for context)
+
+- Issue #108: original body + update comment (with the 102-line gap finding, surgical-only decision, runtime-state notes, installer behavior summary)
+- Issue #109: original body + update comment (with the Path A/B decision matrix and tonight's scope)
+- Issue #110: original body + update comment (with installer behavior, #115 cross-ref, deferral rationale)
+- Issue #115: filed today, contains full analysis of `engine/actions.ts:498-577` hardcoded URL behavior
+- Backup at `~/backups/pai/claude-20260414-004729/` — full byte-verified copy of `~/.claude/PAI/` and `~/.claude/PAI-Install/` as they existed before deletion

--- a/Plans/eager-enchanting-snail.md
+++ b/Plans/eager-enchanting-snail.md
@@ -1,0 +1,95 @@
+# Plan: Create GitHub Issue for PAI Directory Move
+
+## Context
+
+Ian wants to relocate `~/.claude/PAI/` to `~/data/PAI/` and update all references. This is a significant infrastructure change because PAI's path is baked into 100+ files across settings, hooks, tools, skills, documentation, and the source repo.
+
+**Core architectural tension:** `PAI_DIR` env var currently = `~/.claude` (Claude Code config root, NOT the PAI subdirectory). It's used for hooks (`${PAI_DIR}/hooks/...`), settings path resolution, MEMORY directory, etc. Moving just `PAI/` out means `PAI_DIR` can no longer serve double duty.
+
+**The hooks directory (`~/.claude/hooks/`) uses relative imports like `../PAI/Tools/Inference`** — these break if PAI/ moves but hooks stay. This is the highest-risk change.
+
+## Task
+
+Create a comprehensive GitHub issue (type: Task) that captures:
+1. Complete scope of the move
+2. All affected file categories with counts
+3. The env var architecture decision
+4. Step-by-step execution plan
+5. Verification checklist
+6. Risk mitigation (symlink transition)
+
+## Execution
+
+1. Create the issue using `gh issue create --repo virtualian/pai` with a detailed body
+2. The issue body will include all findings from the audit
+
+## Issue Structure
+
+### Title
+`Move PAI installation from ~/.claude/PAI/ to ~/data/PAI/`
+
+### Body sections
+- **Problem/Motivation** — why the move
+- **Scope** — what moves, what stays
+- **Architecture Decision: Env Vars** — introduce `PAI_INSTALL_DIR`
+- **Affected Files** — categorized with counts
+- **Execution Plan** — ordered steps
+- **Verification** — how to confirm success
+- **Rollback** — symlink strategy
+
+### Key details for the issue:
+
+**What moves:**
+- `~/.claude/PAI/` → `~/data/PAI/`
+- `~/.claude/PAI-Install/` → `~/data/PAI-Install/` (associated)
+
+**What stays:**
+- `~/.claude/hooks/` — stays (but imports updated)
+- `~/.claude/MEMORY/` — stays
+- `~/.claude/settings.json` — stays (updated)
+- `~/.claude/CLAUDE.md` — stays (updated)
+- `~/.config/PAI/` — stays (already separate)
+
+**Env var changes:**
+- Keep `PAI_DIR` = `~/.claude` (Claude home, used by hooks/MEMORY/settings)
+- Add `PAI_INSTALL_DIR` = `~/data/PAI` (where PAI code lives)
+- Update `paths.ts` to expose `getPaiInstallDir()`
+
+**File categories affected:**
+1. `settings.json` — add env var, update loadAtStartup paths (~5 changes)
+2. `CLAUDE.md` — update 3 hardcoded `~/.claude/PAI/` paths
+3. `hooks/lib/paths.ts` — add `getPaiInstallDir()` function
+4. Hook .ts files — update 6+ relative imports from `../PAI/` to use new function
+5. PAI Tool scripts — update ~12 files with `process.env.HOME + '/.claude'` patterns
+6. PAI documentation (.md) — update ~120 path references across ~15 files
+7. Skill SKILL.md files — update ~20 `~/.claude/PAI/USER/` references
+8. Algorithm v3.7.0.md — update ~8 path references
+9. Source repo templates — update installer/releases
+10. `LOCAL_PATCHES.md` — update 2 hardcoded paths
+
+**Execution order:**
+1. Create `~/data/` directory
+2. Update env vars in settings.json (add PAI_INSTALL_DIR)
+3. Update paths.ts (add getPaiInstallDir)
+4. Update hook imports to use absolute paths via getPaiInstallDir
+5. Update PAI internal self-references (Tools/*.ts)
+6. Update CLAUDE.md hardcoded paths
+7. Update all documentation references
+8. Move the directory
+9. Create symlink ~/.claude/PAI → ~/data/PAI (transition safety)
+10. Test: hooks, Algorithm, Notify.ts, skills
+11. Update source repo templates
+12. Remove symlink after verification
+
+## Verification
+
+After creating the issue, confirm it exists and has correct labels.
+
+## Critical files
+- `/Users/ianmarr/.claude/settings.json` — env vars, hooks, loadAtStartup
+- `/Users/ianmarr/.claude/CLAUDE.md` — hardcoded PAI paths
+- `/Users/ianmarr/.claude/hooks/lib/paths.ts` — central path resolution
+- `/Users/ianmarr/.claude/hooks/*.ts` — relative imports
+- `/Users/ianmarr/.claude/PAI/Tools/*.ts` — self-references
+- `/Users/ianmarr/.claude/PAI/Algorithm/v3.7.0.md` — path references
+- `/Users/ianmarr/.claude/PAI/*.md` — all documentation


### PR DESCRIPTION
## Summary

Commits three \`Plans/\` documents that have been sitting untracked in the working tree. No code changes — pure documentation archive. The goal is to resolve working-tree drift between design docs and git state, and specifically to make pre-existing PR citations resolvable against real files in git.

## What's in the commit

### 1. \`Plans/2026-04-14-two-root-separation-followups.md\` (238 lines)

**The authoritative planning doc for issues #108, #109, #110, and #115.** Already cited by merged PRs #117, #118, and #119 as design reference — but until this PR, anyone reading those merged PRs and following the \`Plans/2026-04-14-two-root-separation-followups.md\` citation would get a 404. This commit makes the citation chain resolve for the first time.

Contents:
- Problem framing for the #108/#109/#110/#115 cluster
- "Tonight's scope decision" documenting why #108+#109 were implemented and #110+#115 deferred
- Path A vs Path B decision record for the \`~/.pai/MEMORY/FEEDBACK/\` location question that drove #118/#119
- Per-issue execution notes and open design questions

### 2. \`Plans/2026-04-14-110-mirror-source-investigation.md\` (new, from this session)

**Post-#115-merge investigation** answering the "where does the 178 MB \`~/.claude/skills/\` ↔ \`~/.pai/skills/\` mirror come from?" question that the followups doc left open for a future design phase.

Key findings:
- **Path A confirmed:** the mirror is static. No active code path in \`Releases/v4.0.3+/.claude/\` writes either tree
- Installer's \`paiDir\` variable is semantically \`~/.claude/\` despite its misleading name — it has no code path that can touch \`~/.pai/skills/\`
- Filesystem mtime forensics show \`~/.pai/skills/\` was populated in a Mar 19 batch and has not been updated since Apr 7 2026
- **Critically:** #101 (two-root separation) merged 2026-04-12 — *after* the Mar 19 batch, so \`~/.pai/skills/\` predates the architectural ratification that was supposed to create it

Three Option B implementation variants scoped with tradeoffs:
- **B-Plan-1 (recommended):** copy-then-symlink after git clone; minimum installer disruption
- **B-Plan-2:** clone-target refactor (clone to \`~/.pai/\` instead of \`~/.claude/\`); cleanest but biggest blast radius
- **B-Plan-0:** upstream Claude Code feature request (\`skillsPaths\` in settings.json); zero symlinks once it lands, unknown timeline

Five open questions for next session listed explicitly so the #110 design work can resume cleanly without rediscovering context.

### 3. \`Plans/eager-enchanting-snail.md\` (95 lines)

**Historical planning artifact**, preserved as context. Proposes relocating \`~/.claude/PAI/\` → \`~/data/PAI/\` with a new \`PAI_INSTALL_DIR\` env var.

**Superseded:** #98/#101 chose the two-root separation (\`CLAUDE_CONFIG_DIR + PAI_DIR = ~/.pai\`) instead of this relocation approach. Not an active plan. Committed for archaeological completeness so a future session reading \`Plans/\` chronologically can see both directions that were considered.

## Why committed as one PR

- All three files are in the same \`Plans/\` directory and all three are design documents for the two-root cluster
- The #115/#110 investigation findings are continuous with the followups doc — splitting them into separate PRs would create artificial review boundaries around what is conceptually one design conversation spread across one day
- No code changes means the PR has zero review risk beyond reading the docs themselves

## Scope excluded (intentional)

Still sitting untracked in the working tree, **not** committed here:

- \`CLAUDE.md\` → \`.claude/CLAUDE.md\` file move (different category — config file, not a planning doc, likely from an earlier incomplete session)
- \`reports/2026-04-08-researcher-agent-architecture.md\` (different directory, different category — research report rather than planning)

Filed for a future cleanup pass if you want them tracked.

## Test plan

- [x] \`git commit\` succeeds
- [x] No code files touched (\`git diff --stat\` shows only \`Plans/*.md\`)
- [x] \`git push -u origin plans/two-root-design-docs\` succeeds
- [ ] Merged-PR citations to \`Plans/2026-04-14-two-root-separation-followups.md\` in #117, #118, and #119 now resolve to a real file in git (verifiable post-merge by clicking the link in any of those PRs)

## Related

- Makes pre-existing citations in #117, #118, #119 resolvable
- Context for future work on #110 (via the mirror-source investigation doc)
- Historical record of abandoned \`~/data/PAI/\` direction superseded by #98/#101 (via the eager-enchanting-snail doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)