### PR TITLE
Canonicalize PAI skills via per-pack symlinks (#110)

### DIFF
--- a/Releases/v4.0.3+/.claude/PAI-Install/engine/actions.ts
+++ b/Releases/v4.0.3+/.claude/PAI-Install/engine/actions.ts
@@ -5,7 +5,7 @@
  */
 
 import { execSync, spawn } from "child_process";
-import { existsSync, mkdirSync, writeFileSync, readFileSync, readdirSync, symlinkSync, unlinkSync, chmodSync, lstatSync, cpSync, rmSync } from "fs";
+import { existsSync, mkdirSync, writeFileSync, readFileSync, readdirSync, symlinkSync, unlinkSync, chmodSync, lstatSync, statSync, cpSync, rmSync } from "fs";
 import { homedir } from "os";
 import { join, basename } from "path";
 import type { InstallState, EngineEventHandler, DetectionResult } from "./types";
@@ -13,6 +13,7 @@ import { PAI_VERSION, ALGORITHM_VERSION } from "./types";
 import { detectSystem, validateElevenLabsKey } from "./detect";
 import { generateSettingsJson } from "./config-gen";
 import { resolveRepoUrl, readOriginRemote } from "./repo-url";
+import { migratePerPackSymlinks } from "./skill-migration";
 
 /**
  * Remove duplicate bun PATH entries from shell config.
@@ -589,6 +590,12 @@ export async function runRepository(
     await migrateUserContext(paiDir, emit);
   }
 
+  // Canonicalize each PAI-owned skill pack as a symlink from ~/.claude/skills
+  // to ~/.pai/skills (GitHub #110). Runs on both fresh and upgrade paths:
+  // on fresh, closes the drift window before it opens; on upgrade, converts
+  // pre-existing real directories to symlinks idempotently.
+  await migratePerPackSymlinks(paiDir, emit);
+
   await emit({ event: "progress", step: "repository", percent: 100, detail: "Repository ready" });
   await emit({ event: "step_complete", step: "repository" });
 }
@@ -676,11 +683,24 @@ export async function runConfiguration(
       return count;
     };
 
+    // Accept both real directories AND symlinks whose targets are directories.
+    // Post-#110 per-pack symlinks: PAI skill packs under ~/.claude/skills/ are
+    // now symlinks to ~/.pai/skills/<pack>, and readdirSync's Dirent returns
+    // isDirectory() === false for symlinks (it uses lstat semantics). Without
+    // the symlink-aware branch below, the skill-count banner would undercount
+    // every canonicalized pack.
     const countDirs = (dir: string, filter?: (name: string) => boolean): number => {
       if (!existsSync(dir)) return 0;
       try {
         return readdirSync(dir, { withFileTypes: true })
-          .filter(e => e.isDirectory() && (!filter || filter(e.name))).length;
+          .filter(e => {
+            if (e.isDirectory()) return true;
+            if (e.isSymbolicLink()) {
+              try { return statSync(join(dir, e.name)).isDirectory(); } catch { return false; }
+            }
+            return false;
+          })
+          .filter(e => !filter || filter(e.name)).length;
       } catch { return 0; }
     };
 
@@ -695,7 +715,12 @@ export async function runConfiguration(
     if (existsSync(skillsDir)) {
       try {
         for (const s of readdirSync(skillsDir, { withFileTypes: true })) {
-          if (s.isDirectory()) {
+          // Accept real dirs and symlinks-to-dirs (post-#110 per-pack symlinks).
+          let isDirLike = s.isDirectory();
+          if (!isDirLike && s.isSymbolicLink()) {
+            try { isDirLike = statSync(join(skillsDir, s.name)).isDirectory(); } catch {}
+          }
+          if (isDirLike) {
             const toolsDir = join(skillsDir, s.name, "Tools");
             if (existsSync(toolsDir)) {
               workflowCount += countFiles(toolsDir, ".ts");

--- a/Releases/v4.0.3+/.claude/PAI-Install/engine/skill-migration.test.ts
+++ b/Releases/v4.0.3+/.claude/PAI-Install/engine/skill-migration.test.ts
@@ -1,0 +1,301 @@
+/**
+ * PAI Installer v4.0 — Per-Pack Skill Symlinks Tests (GitHub #110)
+ *
+ * First-ever engine-level test in PAI-Install. Runs via `bun test` which
+ * auto-discovers *.test.ts files; no package.json config needed.
+ *
+ * Run from Releases/v4.0.3+/.claude/PAI-Install/:
+ *   bun test engine/skill-migration.test.ts
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdirSync,
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  lstatSync,
+  readlinkSync,
+  symlinkSync,
+  rmSync,
+  existsSync,
+  readdirSync,
+} from "fs";
+import { homedir, tmpdir } from "os";
+import { join } from "path";
+import type { EngineEvent } from "./types";
+import {
+  classifySkillDir,
+  migratePerPackSymlinks,
+} from "./skill-migration";
+
+// ─── Fixture helpers ─────────────────────────────────────────────
+
+interface Fixture {
+  root: string;          // tempdir root
+  paiDirArg: string;     // "paiDir" arg passed to migratePerPackSymlinks (= claude root)
+  claudeSkillsDir: string;
+  paiSkillsDir: string;
+  events: EngineEvent[];
+  emit: (e: EngineEvent) => void;
+  cleanup: () => void;
+}
+
+function setupFixture(): Fixture {
+  const root = mkdtempSync(join(tmpdir(), "pai-skill-mig-"));
+  const claudeHome = join(root, "claude");
+  const paiHome = join(root, "pai");
+  mkdirSync(claudeHome, { recursive: true });
+  mkdirSync(paiHome, { recursive: true });
+
+  const claudeSkillsDir = join(claudeHome, "skills");
+  const paiSkillsDir = join(paiHome, "skills");
+  mkdirSync(claudeSkillsDir, { recursive: true });
+  // Intentionally DO NOT create paiSkillsDir here — migration should create it.
+
+  process.env.PAI_DIR = paiHome;
+
+  const events: EngineEvent[] = [];
+  const emit = (e: EngineEvent): void => { events.push(e); };
+
+  return {
+    root,
+    paiDirArg: claudeHome,
+    claudeSkillsDir,
+    paiSkillsDir,
+    events,
+    emit,
+    cleanup: () => {
+      delete process.env.PAI_DIR;
+      try { rmSync(root, { recursive: true, force: true }); } catch { /* best effort */ }
+    },
+  };
+}
+
+function makePackDir(parent: string, name: string, skillMdContent = `name: ${name}`): string {
+  const dir = join(parent, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "SKILL.md"), skillMdContent);
+  return dir;
+}
+
+// ─── classifySkillDir — 6 branches ───────────────────────────────
+
+describe("classifySkillDir", () => {
+  let fx: Fixture;
+  beforeEach(() => { fx = setupFixture(); mkdirSync(fx.paiSkillsDir, { recursive: true }); });
+  afterEach(() => fx.cleanup());
+
+  test("skip-system-dir for PAI", () => {
+    expect(classifySkillDir("PAI", fx.claudeSkillsDir, fx.paiSkillsDir, new Set()))
+      .toBe("skip-system-dir");
+  });
+
+  test("skip-system-dir for CORE", () => {
+    expect(classifySkillDir("CORE", fx.claudeSkillsDir, fx.paiSkillsDir, new Set()))
+      .toBe("skip-system-dir");
+  });
+
+  test("already-correct-symlink when claude side points at pai side", () => {
+    makePackDir(fx.paiSkillsDir, "Research");
+    symlinkSync(join("..", "..", "pai", "skills", "Research"), join(fx.claudeSkillsDir, "Research"));
+    expect(classifySkillDir("Research", fx.claudeSkillsDir, fx.paiSkillsDir, new Set(["Research"])))
+      .toBe("already-correct-symlink");
+  });
+
+  test("external-symlink when claude side points elsewhere", () => {
+    const external = join(fx.root, "elsewhere", "find-skills");
+    mkdirSync(external, { recursive: true });
+    symlinkSync(external, join(fx.claudeSkillsDir, "find-skills"));
+    expect(classifySkillDir("find-skills", fx.claudeSkillsDir, fx.paiSkillsDir, new Set()))
+      .toBe("external-symlink");
+  });
+
+  test("third-party when name not in paiOwnedSet", () => {
+    makePackDir(fx.claudeSkillsDir, "tts-tutor-skill");
+    expect(classifySkillDir("tts-tutor-skill", fx.claudeSkillsDir, fx.paiSkillsDir, new Set(["Research"])))
+      .toBe("third-party");
+  });
+
+  test("pai-only-claude-side when dir only in claude tree", () => {
+    makePackDir(fx.claudeSkillsDir, "Research");
+    expect(classifySkillDir("Research", fx.claudeSkillsDir, fx.paiSkillsDir, new Set(["Research"])))
+      .toBe("pai-only-claude-side");
+  });
+
+  test("pai-only-pai-side when dir only in pai tree", () => {
+    makePackDir(fx.paiSkillsDir, "Research");
+    expect(classifySkillDir("Research", fx.claudeSkillsDir, fx.paiSkillsDir, new Set(["Research"])))
+      .toBe("pai-only-pai-side");
+  });
+
+  test("drift-both-sides when both trees have real dirs", () => {
+    makePackDir(fx.claudeSkillsDir, "Research", "claude-version");
+    makePackDir(fx.paiSkillsDir, "Research", "pai-version");
+    expect(classifySkillDir("Research", fx.claudeSkillsDir, fx.paiSkillsDir, new Set(["Research"])))
+      .toBe("drift-both-sides");
+  });
+});
+
+// ─── migratePerPackSymlinks — integration ────────────────────────
+
+describe("migratePerPackSymlinks", () => {
+  let fx: Fixture;
+  beforeEach(() => { fx = setupFixture(); });
+  afterEach(() => fx.cleanup());
+
+  test("fresh install: all claude-side dirs become symlinks to pai side", async () => {
+    makePackDir(fx.claudeSkillsDir, "Research");
+    makePackDir(fx.claudeSkillsDir, "Telos");
+
+    const summary = await migratePerPackSymlinks(fx.paiDirArg, fx.emit);
+
+    expect(summary.migrated).toBe(2);
+    expect(summary.failed).toBe(0);
+    expect(lstatSync(join(fx.claudeSkillsDir, "Research")).isSymbolicLink()).toBe(true);
+    expect(lstatSync(join(fx.claudeSkillsDir, "Telos")).isSymbolicLink()).toBe(true);
+    // Symlink target must be relative
+    expect(readlinkSync(join(fx.claudeSkillsDir, "Research")).startsWith("/")).toBe(false);
+    // Content resolved through the symlink
+    expect(readFileSync(join(fx.claudeSkillsDir, "Research", "SKILL.md"), "utf-8"))
+      .toBe("name: Research");
+    // pai side now has real dirs
+    expect(lstatSync(join(fx.paiSkillsDir, "Research")).isDirectory()).toBe(true);
+    expect(lstatSync(join(fx.paiSkillsDir, "Research")).isSymbolicLink()).toBe(false);
+  });
+
+  test("pai-only-pai-side: creates symlink without data move", async () => {
+    mkdirSync(fx.paiSkillsDir, { recursive: true });
+    makePackDir(fx.paiSkillsDir, "Research", "original-content");
+
+    const summary = await migratePerPackSymlinks(fx.paiDirArg, fx.emit);
+
+    expect(summary.migrated).toBe(1);
+    expect(lstatSync(join(fx.claudeSkillsDir, "Research")).isSymbolicLink()).toBe(true);
+    // Original content preserved
+    expect(readFileSync(join(fx.paiSkillsDir, "Research", "SKILL.md"), "utf-8"))
+      .toBe("original-content");
+  });
+
+  test("drift: pai side backed up before claude side wins", async () => {
+    mkdirSync(fx.paiSkillsDir, { recursive: true });
+    makePackDir(fx.claudeSkillsDir, "Research", "claude-wins");
+    makePackDir(fx.paiSkillsDir, "Research", "pai-loses");
+
+    const summary = await migratePerPackSymlinks(fx.paiDirArg, fx.emit);
+
+    expect(summary.migrated).toBe(1);
+    expect(summary.backedUp).toBe(1);
+    // Final canonical content is the claude version
+    expect(readFileSync(join(fx.paiSkillsDir, "Research", "SKILL.md"), "utf-8"))
+      .toBe("claude-wins");
+    // Old pai content preserved in a backup sibling
+    const backups = readdirSync(fx.paiSkillsDir).filter(n => n.startsWith("Research.backup-"));
+    expect(backups.length).toBe(1);
+    expect(readFileSync(join(fx.paiSkillsDir, backups[0], "SKILL.md"), "utf-8"))
+      .toBe("pai-loses");
+  });
+
+  test("third-party skills are preserved", async () => {
+    // Simulate upgrade: pai side already has canonical packs.
+    mkdirSync(fx.paiSkillsDir, { recursive: true });
+    makePackDir(fx.paiSkillsDir, "Research");
+    // Claude side has a third-party pack absent from pai.
+    makePackDir(fx.claudeSkillsDir, "tts-tutor-skill");
+
+    const summary = await migratePerPackSymlinks(fx.paiDirArg, fx.emit);
+
+    expect(summary.failed).toBe(0);
+    // Third-party is untouched — still a real directory, not a symlink.
+    const thirdParty = lstatSync(join(fx.claudeSkillsDir, "tts-tutor-skill"));
+    expect(thirdParty.isDirectory()).toBe(true);
+    expect(thirdParty.isSymbolicLink()).toBe(false);
+    // pai side did NOT get a tts-tutor-skill entry
+    expect(existsSync(join(fx.paiSkillsDir, "tts-tutor-skill"))).toBe(false);
+  });
+
+  test("external symlinks (find-skills) are preserved untouched", async () => {
+    const external = join(fx.root, "agents-home", "find-skills");
+    mkdirSync(external, { recursive: true });
+    writeFileSync(join(external, "SKILL.md"), "find-skills-content");
+    mkdirSync(fx.paiSkillsDir, { recursive: true });
+    makePackDir(fx.paiSkillsDir, "Research"); // another pack, to make paiOwnedSet non-empty
+    symlinkSync(external, join(fx.claudeSkillsDir, "find-skills"));
+
+    await migratePerPackSymlinks(fx.paiDirArg, fx.emit);
+
+    // find-skills is still a symlink pointing at the external location.
+    const stat = lstatSync(join(fx.claudeSkillsDir, "find-skills"));
+    expect(stat.isSymbolicLink()).toBe(true);
+    expect(readlinkSync(join(fx.claudeSkillsDir, "find-skills"))).toBe(external);
+    // Nothing was written to pai side for it.
+    expect(existsSync(join(fx.paiSkillsDir, "find-skills"))).toBe(false);
+  });
+
+  test("idempotency: second run is a no-op", async () => {
+    makePackDir(fx.claudeSkillsDir, "Research");
+
+    const first = await migratePerPackSymlinks(fx.paiDirArg, fx.emit);
+    expect(first.migrated).toBe(1);
+
+    fx.events.length = 0; // clear event log
+    const second = await migratePerPackSymlinks(fx.paiDirArg, fx.emit);
+
+    expect(second.migrated).toBe(0);
+    expect(second.failed).toBe(0);
+    expect(second.skipped).toBeGreaterThanOrEqual(1);
+    // No "migrated" messages should have been emitted on the second run.
+    const migratedMsgs = fx.events.filter(
+      e => e.event === "message" && (e as { content?: string }).content?.includes("migrated to"),
+    );
+    expect(migratedMsgs.length).toBe(0);
+  });
+
+  test(".DS_Store and ._* entries are ignored at top level", async () => {
+    makePackDir(fx.claudeSkillsDir, "Research");
+    writeFileSync(join(fx.claudeSkillsDir, ".DS_Store"), "junk");
+    writeFileSync(join(fx.claudeSkillsDir, "._apple-fork"), "junk");
+
+    const summary = await migratePerPackSymlinks(fx.paiDirArg, fx.emit);
+
+    expect(summary.migrated).toBe(1); // only Research
+    // The junk entries must NOT appear in the pai tree.
+    expect(existsSync(join(fx.paiSkillsDir, ".DS_Store"))).toBe(false);
+    expect(existsSync(join(fx.paiSkillsDir, "._apple-fork"))).toBe(false);
+  });
+
+  test("idempotency on a drifted tree: backup dirs do not get re-migrated on second run", async () => {
+    // Setup drift: both sides have real Research dirs with different content.
+    mkdirSync(fx.paiSkillsDir, { recursive: true });
+    makePackDir(fx.claudeSkillsDir, "Research", "claude-wins");
+    makePackDir(fx.paiSkillsDir, "Research", "pai-loses");
+
+    // First run: creates a backup dir in pai tree.
+    const first = await migratePerPackSymlinks(fx.paiDirArg, fx.emit);
+    expect(first.migrated).toBe(1);
+    expect(first.backedUp).toBe(1);
+    const backups = readdirSync(fx.paiSkillsDir).filter(n => n.startsWith("Research.backup-"));
+    expect(backups.length).toBe(1);
+
+    // Second run: must NOT symlink the backup dir from pai side to claude side.
+    fx.events.length = 0;
+    const second = await migratePerPackSymlinks(fx.paiDirArg, fx.emit);
+    expect(second.migrated).toBe(0);
+    expect(second.backedUp).toBe(0);
+    expect(second.failed).toBe(0);
+    // No entry for the backup dir should have been created on claude side.
+    expect(existsSync(join(fx.claudeSkillsDir, backups[0]))).toBe(false);
+  });
+
+  test("PAI and CORE top-level names are skipped", async () => {
+    makePackDir(fx.claudeSkillsDir, "PAI");
+    makePackDir(fx.claudeSkillsDir, "Research");
+
+    const summary = await migratePerPackSymlinks(fx.paiDirArg, fx.emit);
+
+    // Only Research is migrated. PAI is skipped as a system dir.
+    expect(summary.migrated).toBe(1);
+    expect(lstatSync(join(fx.claudeSkillsDir, "PAI")).isSymbolicLink()).toBe(false);
+    expect(lstatSync(join(fx.claudeSkillsDir, "Research")).isSymbolicLink()).toBe(true);
+  });
+});

--- a/Releases/v4.0.3+/.claude/PAI-Install/engine/skill-migration.ts
+++ b/Releases/v4.0.3+/.claude/PAI-Install/engine/skill-migration.ts
@@ -1,0 +1,373 @@
+/**
+ * PAI Installer v4.0 — Per-Pack Skill Symlinks (GitHub #110)
+ *
+ * Converts each PAI-owned directory under `~/.claude/skills/<pack>/` into a
+ * symlink pointing at `~/.pai/skills/<pack>/`. Claude Code's skill scanner is
+ * hardcoded to `~/.claude/skills/`, so the read path stays there while
+ * `~/.pai/skills/` becomes the single source of truth.
+ *
+ * Third-party skills (e.g. tts-tutor-skill) and external symlinks
+ * (e.g. find-skills -> ~/.agents/skills/find-skills) are preserved untouched.
+ *
+ * Ownership rule:
+ *   - If `~/.pai/skills/<name>` exists as a real directory → PAI-owned
+ *   - If `~/.pai/skills/` is empty (fresh install, right after git clone)
+ *     → every top-level dir in `~/.claude/skills/` is PAI-owned. Nothing
+ *     third-party could exist at that moment.
+ *
+ * Precedent: `migrateUserContext` in actions.ts:201 does copy → delete →
+ * symlinkSync for `skills/PAI/USER` and `skills/CORE/USER`. This module
+ * applies the same pattern at top-level pack granularity.
+ *
+ * Ordering: runs AFTER `migrateUserContext` in `runRepository`, so any
+ * `skills/PAI/USER` or `skills/CORE/USER` subdirs have already been
+ * converted to symlinks before our top-level iteration sees them.
+ * We also skip any literal `PAI` / `CORE` top-level names defensively.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readlinkSync,
+  lstatSync,
+  symlinkSync,
+  renameSync,
+  rmSync,
+  cpSync,
+} from "fs";
+import { homedir } from "os";
+import { join, resolve, relative, basename } from "path";
+import type { EngineEventHandler } from "./types";
+
+export type PackClassification =
+  | "already-correct-symlink"
+  | "external-symlink"
+  | "third-party"
+  | "pai-only-claude-side"
+  | "pai-only-pai-side"
+  | "drift-both-sides"
+  | "skip-system-dir";
+
+export interface MigrationSummary {
+  migrated: number;
+  skipped: number;
+  backedUp: number;
+  failed: number;
+}
+
+// Top-level names that must never be processed by this migration.
+// Historical v2.x/v3.x user-context homes. `migrateUserContext` in actions.ts
+// handles their USER subdirs separately.
+const SKIP_SYSTEM_DIRS = new Set(["PAI", "CORE"]);
+
+const IGNORED_ENTRIES = new Set([".DS_Store"]);
+
+// Matches the backup suffix this module creates during drift resolution:
+// `<pack>.backup-YYYY-MM-DDTHH-MM-SS-sssZ`. Backups must be invisible to
+// subsequent migration runs so they don't get re-symlinked.
+const BACKUP_SUFFIX_RE = /\.backup-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z$/;
+
+function isIgnored(name: string): boolean {
+  if (IGNORED_ENTRIES.has(name)) return true;
+  if (name.startsWith("._")) return true;
+  if (BACKUP_SUFFIX_RE.test(name)) return true;
+  return false;
+}
+
+/**
+ * Resolve the canonical PAI skills directory.
+ * Uses PAI_DIR env var if set (test-mode override or custom install layout),
+ * otherwise defaults to `~/.pai/skills`. A `~/` or `$HOME/` prefix on the
+ * env var value is expanded so user-supplied overrides work.
+ *
+ * This is DIFFERENT from the installer's `paiDir` variable in actions.ts,
+ * which is misleadingly named and always resolves to `~/.claude/`.
+ */
+function getPaiSkillsDir(): string {
+  let envPaiDir = (process.env.PAI_DIR || "").trim();
+  if (envPaiDir === "~" || envPaiDir.startsWith("~/")) {
+    envPaiDir = join(homedir(), envPaiDir.slice(1));
+  } else if (envPaiDir.startsWith("$HOME")) {
+    envPaiDir = join(homedir(), envPaiDir.slice("$HOME".length));
+  }
+  const paiHome = envPaiDir || join(homedir(), ".pai");
+  return join(paiHome, "skills");
+}
+
+/**
+ * Enumerate top-level pack names under `dir` that are real directories
+ * (not symlinks, not ignored, not system dirs). Used to compute the PAI-owned
+ * set from either the canonical pai tree (normal upgrade) or the claude tree
+ * (fresh install, where the pai tree is empty).
+ */
+function collectOwnedDirs(dir: string): Set<string> {
+  const out = new Set<string>();
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    if (isIgnored(e.name)) continue;
+    if (SKIP_SYSTEM_DIRS.has(e.name)) continue;
+    if (e.isDirectory() && !e.isSymbolicLink()) {
+      out.add(e.name);
+    }
+  }
+  return out;
+}
+
+/**
+ * `cpSync` filter: skip .DS_Store and macOS resource-fork `._*` files.
+ * Applied at every filesystem copy to keep junk out of the canonical tree.
+ */
+function cpFilter(src: string): boolean {
+  return !isIgnored(basename(src));
+}
+
+/**
+ * Classify a top-level pack name. Pure function — safe to unit-test.
+ * Uses lstatSync (never statSync) so `find-skills` (external symlink) is
+ * correctly detected as a symbolic link and classified "external-symlink".
+ */
+export function classifySkillDir(
+  name: string,
+  claudeSkillsDir: string,
+  paiSkillsDir: string,
+  paiOwnedSet: Set<string>,
+): PackClassification {
+  if (SKIP_SYSTEM_DIRS.has(name)) return "skip-system-dir";
+
+  const claudeSide = join(claudeSkillsDir, name);
+  const paiSide = join(paiSkillsDir, name);
+
+  let claudeStat: ReturnType<typeof lstatSync> | null = null;
+  let paiStat: ReturnType<typeof lstatSync> | null = null;
+  try { claudeStat = lstatSync(claudeSide); } catch { /* absent */ }
+  try { paiStat = lstatSync(paiSide); } catch { /* absent */ }
+
+  if (claudeStat?.isSymbolicLink()) {
+    let target: string;
+    try { target = readlinkSync(claudeSide); }
+    catch { return "external-symlink"; }
+    const resolvedTarget = resolve(claudeSkillsDir, target);
+    const expected = resolve(paiSide);
+    return resolvedTarget === expected ? "already-correct-symlink" : "external-symlink";
+  }
+
+  const claudeIsDir = claudeStat !== null && claudeStat.isDirectory();
+  const paiIsDir = paiStat !== null && paiStat.isDirectory() && !paiStat.isSymbolicLink();
+
+  if (!paiOwnedSet.has(name)) {
+    return "third-party";
+  }
+
+  if (claudeIsDir && paiIsDir) return "drift-both-sides";
+  if (claudeIsDir && !paiIsDir) return "pai-only-claude-side";
+  if (!claudeIsDir && paiIsDir) return "pai-only-pai-side";
+
+  // Both absent. Shouldn't reach this branch if `name` came from an enumeration.
+  return "third-party";
+}
+
+type MigrateMode = "move" | "link-only" | "drift";
+
+/**
+ * Migrate a single pack. Atomic per-pack state machine with rollback.
+ *
+ * Modes:
+ *   "move"       — claude side has the data; move it to pai, symlink back
+ *   "link-only"  — pai side already has the data; just create the symlink
+ *   "drift"      — both sides have real dirs; back up pai, move claude over, symlink
+ */
+async function migratePack(
+  name: string,
+  claudeSkillsDir: string,
+  paiSkillsDir: string,
+  mode: MigrateMode,
+  summary: MigrationSummary,
+  emit: EngineEventHandler,
+): Promise<void> {
+  const claudeSide = join(claudeSkillsDir, name);
+  const paiSide = join(paiSkillsDir, name);
+  // Relative symlink target, computed from the symlink's parent directory.
+  // Symlink lives at claudeSkillsDir/<name>; parent = claudeSkillsDir.
+  const relativeTarget = relative(claudeSkillsDir, paiSide);
+
+  // STATE 1 — drift backup: rename the losing side (pai) to a timestamped sibling.
+  let backupPath: string | null = null;
+  if (mode === "drift") {
+    const ts = new Date().toISOString().replace(/[:.]/g, "-");
+    backupPath = join(paiSkillsDir, `${name}.backup-${ts}`);
+    renameSync(paiSide, backupPath);
+    summary.backedUp++;
+    await emit({
+      event: "message",
+      content: `Skill "${name}": drift detected, backed up ~/.pai/skills/${name} → ${basename(backupPath)}`,
+    });
+  }
+
+  // STATE 2 — move data from claude side into the now-vacated pai slot.
+  // `renameSync` is atomic on same-filesystem. EXDEV / ENOTEMPTY fallback uses
+  // filtered cpSync + rmSync.
+  if (mode === "move" || mode === "drift") {
+    try {
+      renameSync(claudeSide, paiSide);
+    } catch (err: unknown) {
+      const code = (err as { code?: string } | null)?.code;
+      if (code === "EXDEV" || code === "ENOTEMPTY") {
+        // Cross-device or non-empty destination: filtered recursive copy + remove source.
+        cpSync(claudeSide, paiSide, {
+          recursive: true,
+          filter: cpFilter,
+          dereference: false,
+        });
+        rmSync(claudeSide, { recursive: true, force: true });
+      } else {
+        // Unknown failure — restore backup if we had one and re-throw.
+        if (backupPath && !existsSync(paiSide)) {
+          try {
+            renameSync(backupPath, paiSide);
+            summary.backedUp--;
+          } catch { /* best effort */ }
+        }
+        throw err;
+      }
+    }
+  }
+
+  // STATE 3 — create the relative symlink at the claude side.
+  try {
+    symlinkSync(relativeTarget, claudeSide);
+  } catch (err) {
+    // Rollback: undo STATE 2 by renaming pai back to claude, then restore backup.
+    try {
+      if (mode === "move" || mode === "drift") {
+        renameSync(paiSide, claudeSide);
+      }
+      if (backupPath) {
+        renameSync(backupPath, paiSide);
+        summary.backedUp--;
+      }
+    } catch { /* best effort */ }
+    throw err;
+  }
+
+  summary.migrated++;
+  await emit({
+    event: "message",
+    content: `Skill "${name}": migrated to ~/.pai/skills/${name} and symlinked.`,
+  });
+}
+
+/**
+ * Main entry point. Iterates the union of `<claudeDir>/skills` and
+ * `<paiSkillsDir>`, classifies each pack, and migrates PAI-owned ones.
+ *
+ * @param paiDir The installer's `paiDir` variable — SEMANTICALLY the
+ *               Claude Code config root (`~/.claude`), despite the misleading
+ *               name. Pulled straight from actions.ts's resolution so naming
+ *               stays consistent with the rest of that file.
+ * @param emit   Installer event handler.
+ * @returns      A summary counter of packs migrated/skipped/backed-up/failed.
+ *               Soft-fail: a single pack's failure does NOT abort the run.
+ */
+export async function migratePerPackSymlinks(
+  paiDir: string,
+  emit: EngineEventHandler,
+): Promise<MigrationSummary> {
+  const claudeSkillsDir = join(paiDir, "skills");
+  const paiSkillsDir = getPaiSkillsDir();
+  const summary: MigrationSummary = { migrated: 0, skipped: 0, backedUp: 0, failed: 0 };
+
+  if (!existsSync(claudeSkillsDir)) {
+    return summary; // Nothing to migrate.
+  }
+
+  // Ensure the canonical PAI skills directory exists. First-time creation on
+  // fresh installs — this is the first installer code path that touches
+  // `~/.pai/` at all.
+  if (!existsSync(paiSkillsDir)) {
+    mkdirSync(paiSkillsDir, { recursive: true });
+    await emit({
+      event: "message",
+      content: `Created canonical skill directory at ${paiSkillsDir}.`,
+    });
+  }
+
+  // Compute the PAI-owned set. Two modes:
+  //   - If ~/.pai/skills/ already has real subdirs, trust them as the source of truth.
+  //   - Otherwise (fresh install, empty pai side), every non-symlink dir on
+  //     the claude side is PAI-owned — nothing third-party can exist yet.
+  let paiOwnedSet = collectOwnedDirs(paiSkillsDir);
+  if (paiOwnedSet.size === 0) {
+    paiOwnedSet = collectOwnedDirs(claudeSkillsDir);
+  }
+
+  // Iterate the union of both sides.
+  const allNames = new Set<string>();
+  for (const e of readdirSync(claudeSkillsDir, { withFileTypes: true })) {
+    if (!isIgnored(e.name)) allNames.add(e.name);
+  }
+  for (const e of readdirSync(paiSkillsDir, { withFileTypes: true })) {
+    if (!isIgnored(e.name)) allNames.add(e.name);
+  }
+
+  await emit({
+    event: "progress",
+    step: "repository",
+    percent: 80,
+    detail: `Canonicalizing ${paiOwnedSet.size} PAI skill packs...`,
+  });
+
+  for (const name of allNames) {
+    const kind = classifySkillDir(name, claudeSkillsDir, paiSkillsDir, paiOwnedSet);
+    try {
+      switch (kind) {
+        case "already-correct-symlink":
+        case "skip-system-dir":
+          summary.skipped++;
+          break;
+        case "external-symlink":
+          summary.skipped++;
+          await emit({
+            event: "message",
+            content: `Skill "${name}": external symlink preserved.`,
+          });
+          break;
+        case "third-party":
+          summary.skipped++;
+          await emit({
+            event: "message",
+            content: `Skill "${name}": third-party skill preserved.`,
+          });
+          break;
+        case "pai-only-claude-side":
+          await migratePack(name, claudeSkillsDir, paiSkillsDir, "move", summary, emit);
+          break;
+        case "pai-only-pai-side":
+          await migratePack(name, claudeSkillsDir, paiSkillsDir, "link-only", summary, emit);
+          break;
+        case "drift-both-sides":
+          await migratePack(name, claudeSkillsDir, paiSkillsDir, "drift", summary, emit);
+          break;
+      }
+    } catch (err) {
+      summary.failed++;
+      const msg = err instanceof Error ? err.message : String(err);
+      await emit({
+        event: "message",
+        content: `Skill "${name}": migration failed — ${msg}`,
+      });
+    }
+  }
+
+  await emit({
+    event: "message",
+    content:
+      `Skill canonicalization: ${summary.migrated} migrated, ` +
+      `${summary.skipped} skipped, ${summary.backedUp} backed up, ` +
+      `${summary.failed} failed.`,
+  });
+
+  return summary;
+}
+
+// Exposed for tests only.
+export const __testInternals = { getPaiSkillsDir, cpFilter, isIgnored, migratePack };


### PR DESCRIPTION
## Summary

- Canonicalize each PAI-owned pack under `~/.claude/skills/` as a relative symlink to `~/.pai/skills/<pack>`, finally realizing PR #101's two-root design for skills. Claude Code's skill scanner continues to read from `~/.claude/skills/` (unchanged), but the content lives under the canonical PAI code root.
- Third-party packs (`tts-tutor-skill`) and external symlinks (`find-skills`) are detected and preserved untouched. Detection uses an upstream-shipped-set ownership rule so future marketplace installs are automatically left alone.
- Two regression fixes bundled: `countDirs` / workflow count loop in `runConfiguration` now accept symlinks-to-directories (prevents banner undercount by 13 post-migration, since `Dirent.isDirectory()` returns `false` for symlinks on POSIX). Backup-dir ignore filter prevents second-run idempotency break on drifted trees — caught by running against a real 178 MB copy, not by unit tests.

## What changed

| File | Action | Purpose |
|---|---|---|
| `engine/skill-migration.ts` | **new** (~300 lines) | `classifySkillDir` (7 branches) + per-pack state machine with rename→cpSync-on-EXDEV fallback, drift backup to `<pack>.backup-<ISO-ts>/`, rollback on transition failure, soft-fail semantics matching `migrateUserContext` |
| `engine/skill-migration.test.ts` | **new** (17 tests) | First-ever `engine/` test. Covers all 7 classification branches + fresh-install + pai-only + drift-with-backup + third-party + `find-skills` external + idempotency on drifted tree + `.DS_Store`/`._*` filters + `PAI`/`CORE` top-level skip |
| `engine/actions.ts` | modified (+36 / -3) | Import + single call in `runRepository` after `migrateUserContext`. Plus two symlink-aware `statSync` fallbacks in `runConfiguration`'s skill/workflow counting helpers (regression fix ISC-42) |

Mirrors `migrateUserContext`'s existing copy→delete→`symlinkSync` precedent at top-level pack granularity. No new primitives invented.

## Test plan

- [x] `bun test engine/skill-migration.test.ts` → **17 pass, 0 fail, 49 expect() calls**
- [x] Dry-run against 178 MB `cp -a` copy of real `~/.claude/skills/` + `~/.pai/skills/`:
  - Run 1: `{migrated: 13, skipped: 2, backedUp: 13, failed: 0}` (every PAI pack was in drift state)
  - Run 2: `{migrated: 0, skipped: 15, backedUp: 0, failed: 0}` — **idempotent**
- [x] Post-migration `ls -la` shows 13 PAI symlinks + `tts-tutor-skill` regular dir + `find-skills` external symlink + 0 backup dirs visible in claude side
- [x] `readlink ~/.claude/skills/Research` → `../../.pai/skills/Research` (relative, not absolute)
- [x] `SKILL.md` frontmatter loads through each symlink
- [x] Canonical-path proof: `rm -rf ~/.pai/skills/<pack>` breaks `~/.claude/skills/<pack>` discovery — confirms single source of truth
- [ ] Smoke-test against a real fresh install (needs reviewer environment)
- [ ] Smoke-test against a real upgrade install (needs reviewer environment)

## References

- `Plans/2026-04-14-110-mirror-source-investigation.md` — mirror-source investigation confirming Path A (static mirror, no installer writes). Scopes B-Plan-1 and documents three implementation variants.
- `Plans/2026-04-14-two-root-separation-followups.md` — planning doc for the two-root cluster (#108/#109/#110/#115) with per-issue work plans and constraints.
- Builds on #120 (#115 fix) — fork-clone URL configurability, precondition so fork-side fixes reach runtime via reinstall.
- Supersedes Option D (upstream `skillsPaths` feature request) — shelved indefinitely per owner decision; B-Plan-1 is the permanent architecture, not a workaround.

## Out of scope (intentionally deferred)

- `GetCounts.ts:40` has a stale `|| join(HOME, ".claude")` PAI_DIR default — pre-existing #108 territory, not caused by this change, left for a follow-up.
- Windows support — PAI is POSIX-only per existing codebase.
- `Packs/` → `~/.pai/skills/` apply mechanism audit — separate concern, B-Plan-1 doesn't care how the canonical tree is first populated.

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)