### PR TITLE
Fix GetCounts.ts PAI_DIR default + workflow symlink count (#124)

### DIFF
--- a/Releases/v4.0.3+/.claude/PAI/Tools/GetCounts.ts
+++ b/Releases/v4.0.3+/.claude/PAI/Tools/GetCounts.ts
@@ -37,7 +37,11 @@ import { readdirSync, existsSync, statSync } from "fs";
 import { join } from "path";
 
 const HOME = process.env.HOME!;
-const PAI_DIR = process.env.PAI_DIR || join(HOME, ".claude");
+// Two-root default: ~/.pai is the PAI code root (PR #101). PAI_DIR env var
+// overrides if set. Previously fell back to ~/.claude, which is the Claude Code
+// config root and contains no hooks/MEMORY/ structure — silently producing
+// zero counts on any shell that didn't export PAI_DIR. See #124.
+const PAI_DIR = process.env.PAI_DIR || join(HOME, ".pai");
 
 interface Counts {
   skills: number;
@@ -73,19 +77,27 @@ function countFilesRecursive(dir: string, extension?: string): number {
 }
 
 /**
- * Count .md files inside any Workflows directory
+ * Count .md files inside any Workflows directory.
+ *
+ * Accepts real dirs AND symlinks pointing at directories — matches the
+ * pattern used by countSkills below. After #110 per-pack symlinks ship,
+ * pack dirs under ~/.claude/skills/ are symlinks, and Dirent.isDirectory()
+ * returns false for symlinks on POSIX; without the fallback this function
+ * would collapse to near-zero on any read of the ~/.claude side.
  */
 function countWorkflowFiles(dir: string): number {
   let count = 0;
   try {
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
       const fullPath = join(dir, entry.name);
-      if (entry.isDirectory()) {
+      let isDir = entry.isDirectory();
+      if (!isDir && entry.isSymbolicLink()) {
+        try { isDir = statSync(fullPath).isDirectory(); } catch { /* dangling */ }
+      }
+      if (isDir) {
         if (entry.name.toLowerCase() === 'workflows') {
-          // Found a Workflows directory - count all .md files inside
           count += countFilesRecursive(fullPath, '.md');
         } else {
-          // Recurse into subdirectories to find more Workflows dirs
           count += countWorkflowFiles(fullPath);
         }
       }


### PR DESCRIPTION
## Summary

- **Primary:** swap the `PAI_DIR` env var fallback in `GetCounts.ts` from `~/.claude` to `~/.pai`. The stale default predates PR #101's two-root separation and escaped the #108 residual-string sweep because it's a `||` branch rather than a literal path. On any shell that doesn't export `PAI_DIR`, the tool silently read from `~/.claude/` (the Claude Code config root) where there is no `hooks/`, `MEMORY/`, `PAI/USER/` etc. in the two-root architecture — producing zeros for 6 of 8 counts in the Banner and statusline.
- **Defensive:** symlink-harden `countWorkflowFiles` at `GetCounts.ts:78-97` with the same `statSync` fallback already used by `countSkills` a few lines below. `Dirent.isDirectory()` returns `false` for symlinks on POSIX, and after #110 per-pack symlinks ship, any read of `~/.claude/skills/` would find the PAI packs as symlinks — the unfixed helper would collapse to near-zero workflow count. Matches the pattern established in `engine/actions.ts` from PR #123.

## What changed

| File | Lines | Change |
|---|---|---|
| `Releases/v4.0.3+/.claude/PAI/Tools/GetCounts.ts` | +17 / -5 | Line 40: `.claude` → `.pai` default with context comment. Lines 78-97: `countWorkflowFiles` now accepts symlinks-to-directories via the same `statSync` fallback pattern used by `countSkills`. |

## Test plan

- [x] `PAI_DIR= bun GetCounts.ts` **before** fix:
  ```json
  {"skills":15,"workflows":165,"hooks":0,"signals":0,"files":0,"work":0,"research":0,"ratings":0}
  ```
  Six of eight counts are zero — silent breakage.

- [x] `PAI_DIR= bun GetCounts.ts` **after** fix:
  ```json
  {"skills":14,"workflows":165,"hooks":20,"signals":511,"files":13,"work":272,"research":7,"ratings":840}
  ```
  Matches `PAI_DIR=$HOME/.pai bun GetCounts.ts` exactly.

- [x] `PAI_DIR=$HOME/.pai` explicit override: unchanged (still honored, output identical).

- [x] **Synthetic symlinked-tree smoke test** for `countWorkflowFiles`:
  Built `/tmp/fake` with `Research` and `Telos` as symlinks to real directories containing 2 and 1 `Workflows/*.md` files respectively. Ran `GetCounts.ts` against the symlinked side:
  ```json
  {"skills":2,"workflows":3,...}
  ```
  Correct. Without the symlink fallback, `workflows` would be `0`.

- [ ] Smoke-test against a real fresh install (needs reviewer environment)

## References

- PR #123 / issue #110 — per-pack symlinks. This PR is a follow-up to the regression-fix pattern introduced there (`countDirs` symlink-awareness in `engine/actions.ts`).
- #108 — residual `~/.claude/PAI/` references. This `||` default slipped through that sweep because it was syntactically a fallback, not a literal path reference.
- #101 — two-root separation ratification. The `~/.pai` default is the value that should have been set here at #101 time.

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)