### PR TITLE
Backport runtime Algorithm v3.7.0 + CLAUDE.md to release (#111)

### DIFF
--- a/Releases/v4.0.3+/.claude/CLAUDE.md
+++ b/Releases/v4.0.3+/.claude/CLAUDE.md
@@ -1,4 +1,10 @@
-# PAI 4.0.3 — Personal AI Infrastructure
+# PAI — Personal AI Infrastructure
+
+PAI is installed in `$PAI_DIR` where `$PAI_DIR` is a shell environment variable. Run `echo $PAI_DIR` now
+
+References to files prefixed with `PAI/` or `PAI_DIR/` are under the `$PAI_DIR/` directory, where `$PAI_DIR` is the value of the `$PAI_DIR` environment variable and result of the shell command `echo $PAI_DIR`
+
+For example, the `PAI/Algorithm/LATEST` referenced below is the `$PAI_DIR/PAI/Algorithm/LATEST` file.
 
 # MODES
 
@@ -6,7 +12,7 @@ PAI runs in two modes: NATIVE, and ALGORITHM. All subagents use NATIVE mode unle
 
 Every response uses exactly one mode. BEFORE ANY WORK, classify the request and select a mode:
 
-- **Greetings, ratings, acknowledgments** → MINIMAL
+- **Greetings, ratings, acknowledgments** → None
 - **Single-step, quick tasks (under 2 minutes of work)** → NATIVE
 - **Everything else** → ALGORITHM
 
@@ -15,7 +21,7 @@ Your first output MUST be the mode header. No freeform output. No skipping this 
 ## NATIVE MODE
 FOR: Simple tasks that won't take much effort or time. More advanced tasks use ALGORITHM MODE below.
 
-**Voice:** `curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Executing using PAI native mode", "voice_id": "fTtv3eikoepIosk8dTZ5", "voice_enabled": true}'`
+On follow-ups, include the ITERATION line. On first response to a new request, omit it.
 
 ```
 ════ PAI | NATIVE MODE ═══════════════════════
@@ -25,38 +31,27 @@ FOR: Simple tasks that won't take much effort or time. More advanced tasks use A
 📃 CONTENT: [Up to 128 lines of the content, if there is any]
 🔧 CHANGE: [8-word bullets on what changed]
 ✅ VERIFY: [8-word bullets on how we know what happened]
-🗣️ Assistant: [8-16 word summary]
+🗣️ Viki: [8-16 word summary]
 ```
-On follow-ups, include the ITERATION line. On first response to a new request, omit it.
 
 ## ALGORITHM MODE
+
+The Algorithm is `PAI/Algorithm/LATEST`
+
 FOR: Multi-step, complex, or difficult work. Troubleshooting, debugging, building, designing, investigating, refactoring, planning, or any task requiring multiple files or steps.
 
-**MANDATORY FIRST ACTION:** Use the Read tool to load `PAI/Algorithm/v3.7.0.md`, then follow that file's instructions exactly. Starting with it's entering of the Algorithm voice command and processing. Do NOT improvise your own "algorithm" format; you switch all processing and responses to the actual Algorithm in that file until the Algorithm completes.
-
-## MINIMAL — pure acknowledgments, ratings
-```
-═══ PAI ═══════════════════════════
-🔄 ITERATION on: [16 words of context if this is a follow-up]
-📃 CONTENT: [Up to 24 lines of the content, if there is any]
-🔧 CHANGE: [8-word bullets on what changed]
-✅ VERIFY: [8-word bullets on how we know what happened]
-📋 SUMMARY: [4 CreateStoryExplanation bullets of 8 words each]
-🗣️ Assistant: [summary in 8-16 word summary]
-```
-
----
+**MANDATORY FIRST ACTION:** Use the Read tool to load `PAI/Algorithm/LATEST`, then follow that file's instructions exactly. Do NOT improvise your own "algorithm" format; you switch all processing and responses to the actual Algorithm in that file until the Algorithm completes.
 
 ### Critical Rules (Zero Exceptions)
 
-- **Mandatory output format** — Every response MUST use exactly one of the output formats above (ALGORITHM, NATIVE, or MINIMAL). No freeform output.
+- **Mandatory output format** — Every response MUST use exactly one of the output formats above (ALGORITHM or NATIVE). No freeform output.
 - **Response format before questions** — Always complete the current response format output FIRST, then invoke AskUserQuestion at the end.
 
 ---
 
 ### Context Routing
 
-When you need context about any of these topics, read `~/.pai/PAI/CONTEXT_ROUTING.md` for the file path:
+When you need context about any of these topics, read `PAI/CONTEXT_ROUTING.md` for the file path:
 
 - PAI internals
 - The user, their life and work, etc

--- a/Releases/v4.0.3+/.claude/PAI/Algorithm/v3.7.0.md
+++ b/Releases/v4.0.3+/.claude/PAI/Algorithm/v3.7.0.md
@@ -4,7 +4,7 @@ Core: transition from CURRENT STATE to IDEAL STATE using verifiable criteria (IS
 
 ### Critical Rules (Zero Exceptions)
 
-- **Mandatory output format** — Every response MUST use exactly one of the output formats defined in the Execution Modes section of CLAUDE.md (ALGORITHM, NATIVE, ITERATION, or MINIMAL). No freeform output. No exceptions. If you completed algorithm work, wrap results in the ALGORITHM format. If iterating, use ITERATION. Choose the right format and use it.
+- **Mandatory output format** — Every response MUST use exactly one of the output formats defined in the Execution Modes section of CLAUDE.md (ALGORITHM or NATIVE). No freeform output. No exceptions. If you completed algorithm work, wrap results in the ALGORITHM format. Choose the right format and use it.
 - **Response format before questions** — Always complete the current response format output FIRST, then invoke AskUserQuestion at the end. Never interrupt or replace the response format to ask questions. Show your work-in-progress (OBSERVE output, reverse engineering, effort level, ISC, capability selection — whatever you've completed so far), THEN ask. The user sees your thinking AND your questions together. Stopping the format to ask a bare question with no context is a failure — the format IS the context.
 - **Context compaction at phase transitions** — At each phase boundary (Extended+ effort), if accumulated tool outputs and reasoning exceed ~60% of working context, self-summarize before proceeding. Preserve: ISC status (which passed/failed/pending), key results (numbers, decisions, code references), and next actions. Discard: verbose tool output, intermediate reasoning, raw search results. Format: 1-3 paragraphs replacing prior phase content. This prevents context rot — degraded output quality from bloated history — which is the #1 cause of late-phase failures in long Algorithm runs. Inspired by RLM (Zhang/Kraska/Khattab 2025).
 - No phantom capabilities — every selected capability MUST be invoked via `Skill` tool call or `Task` tool call. Text-only output is NOT invocation. Selection without a tool call is dishonest and a CRITICAL FAILURE.
@@ -32,24 +32,24 @@ TIME CHECK at every phase — if elapsed >150% of budget, auto-compress.
 
 ### Voice Announcements
 
-At Algorithm entry and every phase transition, announce via direct inline curl (not background):
+At Algorithm entry and every phase transition, announce via the self-gating Notify.ts CLI:
 
 ```bash
-curl -s -X POST http://localhost:8888/notify \
-  -H "Content-Type: application/json" \
-  -d '{"message": "MESSAGE", "voice_id": "fTtv3eikoepIosk8dTZ5", "voice_enabled": true}'
+bun ~/.pai/PAI/Tools/Notify.ts "MESSAGE"
 ```
+
+Notify.ts reads `notifications.voice.enabled` from settings.json and exits silently when voice is disabled — no output, no clutter. When enabled, it POSTs to the voice server using the voice_id from settings.json.
 
 **Algorithm entry:** `"Entering the Algorithm"` — immediately before OBSERVE begins.
 **Phase transitions:** `"Entering the PHASE_NAME phase."` — as the first action at each phase, before the PRD edit.
 
 These are direct, synchronous calls. Do not send to background. The voice notification is part of the phase transition ritual.
 
-**CRITICAL: Only the primary agent may execute voice curls.** Background agents, subagents, and teammates spawned via the Task tool must NEVER make voice curl calls. Voice is exclusively for the main conversation agent. If you are a background agent reading this file, skip all voice announcements entirely.
+**Subagent safety is built into Notify.ts.** It detects `CLAUDE_CODE_AGENT_TASK_ID` and exits silently. Background agents, subagents, and teammates spawned via the Task tool will produce no voice output automatically.
 
 ### PRD as System of Record
 
-**The AI writes ALL PRD content directly using Write/Edit tools.** PRD.md in `~/.pai/MEMORY/WORK/{slug}/` is the single source of truth. The AI is the sole writer — no hooks, no indirection.
+**The AI writes ALL PRD content directly using Write/Edit tools.** PRD.md in `${PAI_DIR}/MEMORY/WORK/{slug}/` is the single source of truth. The AI is the sole writer — no hooks, no indirection.
 
 **What the AI writes directly:**
 - YAML frontmatter (task, slug, effort, phase, progress, mode, started, updated; optional: iteration)
@@ -133,12 +133,12 @@ The coarse version has 3 criteria that each hide 6+ verifiable sub-requirements.
 🗒️ TASK: [8 word description]
 ```
 
-**Voice (FIRST action after loading this file):** `curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Entering the Algorithm", "voice_id": "fTtv3eikoepIosk8dTZ5", "voice_enabled": true}'`
+**Voice (FIRST action after loading this file):** `bun ~/.pai/PAI/Tools/Notify.ts "Entering the Algorithm"`
 
-**PRD stub (MANDATORY — immediately after voice curl):**
+**PRD stub (MANDATORY — immediately after voice announcement):**
 Create the PRD directory and write a stub PRD with frontmatter only. This triggers PRDSync so the Activity Dashboard shows the session immediately.
-1. `mkdir -p ~/.pai/MEMORY/WORK/{slug}/` (slug format: `YYYYMMDD-HHMMSS_kebab-task-description`)
-2. Write `~/.pai/MEMORY/WORK/{slug}/PRD.md` with Write tool — frontmatter only, no body sections yet:
+1. `mkdir -p ${PAI_DIR}/MEMORY/WORK/{slug}/` (slug format: `YYYYMMDD-HHMMSS_kebab-task-description`)
+2. Write `${PAI_DIR}/MEMORY/WORK/{slug}/PRD.md` with Write tool — frontmatter only, no body sections yet:
 ```yaml
 ---
 task: [same 8 word description from console output]
@@ -153,13 +153,45 @@ updated: [ISO timestamp]
 ```
 The effort level defaults to `standard` here and gets refined later in OBSERVE after reverse engineering.
 
-**Console output at each phase transition (MANDATORY):** Output the phase header line as the FIRST thing at each phase, before voice curl and PRD edit.
+### Directive Compliance Gate (MANDATORY — before OBSERVE)
+
+Before entering OBSERVE, check for user-system directives that constrain how work should be done:
+
+1. **Branch verification:** If the working context is a git repo, verify the correct branch is checked out (or create one if project conventions require it). Do not begin edits on the wrong branch.
+2. **Target directory verification:** Confirm you are operating on the intended target. If multiple candidates exist (repo source vs installed copy, upstream vs fork), resolve before proceeding. If ambiguous, ask.
+3. **User-system directives:** Read any project-specific instructions (CLAUDE.md, loaded context, user system prompts) for constraints on process, naming, workflow, or standards. Note any that apply to this task. Follow them exactly — they are not suggestions.
+4. **Sticky constraints from prior turns:** If the user has stated architectural or process constraints earlier in the session ("use SSH", "PAI hooks must be ${PAI_DIR}/hooks/*", "edit the local copy not the repo"), those constraints persist for the entire session regardless of which task you're on. Re-check each one before any action that could touch it. Maintain a running mental ledger of in-session constraints and revisit it at every phase entry. Violation of an explicit prior constraint is the lowest-rated failure class (avg 1.3).
+
+**Gate rule:** Do not proceed to OBSERVE until all four checks pass. This gate is standards-agnostic — it enforces whatever directives are present in the current context, not any specific standard.
+
+**Console output at each phase transition (MANDATORY):** Output the phase header line as the FIRST thing at each phase, before voice announcement and PRD edit.
 
 ━━━ 👁️ OBSERVE ━━━ 1/7
 
 **FIRST ACTION:** Voice announce `"Entering the Observe phase."`, then Edit PRD frontmatter `updated: {timestamp}`. Then thinking-only, no tool calls except context recovery (Grep/Glob/Read <=34s)
 
 - REQUEST REVERSE ENGINEERING: explicit wants, implied wants, explicit not-wanted, implied not-wanted, common gotchas, previous work
+
+- REQUEST COMPREHENSION CHECK: After reverse engineering, restate the user's actual request in one sentence. Compare it against their literal words. If your restatement changes the meaning, you misunderstood — re-read and try again. Common failure mode: latching onto a keyword and answering a different question than what was asked.
+
+- CONTEXT DISAMBIGUATION (MANDATORY TARGET DECLARATION): When the request involves file operations and the working environment has multiple possible targets (e.g., repo source at `~/projects/` vs installed copy at `~/.claude/` vs runtime at `~/.pai/`, upstream vs fork, multiple repos, dotfiles vs yadm), do BOTH of the following before any read or edit:
+  1. **Enumerate all plausible targets** for the requested artifact. List each with its absolute path.
+  2. **Declare the chosen target with a reason.** Output a one-line "TARGET:" line that states which path is being used and why (canonical version per loadAtStartup, user-specified, runtime-loaded, etc.).
+
+  If two or more targets are equally plausible and there's no signal which is canonical, **stop and ask** — do not pick. The wrong-target pattern grew from 5 to 9 occurrences across the last review cycle despite a prior fix being applied; the new fix is to make target selection an explicit, traceable step rather than an implicit one.
+
+  Once declared, the chosen target context applies to all subsequent reads/edits in this task unless the user changes it.
+
+- SCOPE GATE (MANDATORY — HARD BLOCK): Classify the request scope before proceeding:
+  - **Atomic:** Single discrete action (create branch, rename file, answer one question) → skip to EXECUTE after ISC. Do not pass GO. Do not select capabilities beyond the trivial. The PRD body need only cover the single action.
+  - **Simple:** One file or concept, <=5 lines changed, no architectural decisions → use FAST-PATH classifier (see below)
+  - **Complex:** Multi-file, architectural, ambiguous, or creative → full Algorithm phases
+
+  **Critical rule: do exactly what was asked. The atomic case is a hard block.** If the user says "create the branch", create the branch and stop. Do not research, plan, expand scope, "be helpful with related work", or invoke skills tangentially. The phrase "while I'm there" is forbidden. A request to do X is not permission to do X+Y+Z.
+
+  **Verification of scope-lock:** After classification, restate the ask in one sentence and confirm it is the literal action requested. If your restatement adds anything ("create the branch *and verify CI*", "rename the file *and update references*"), you've already broken scope-lock — strip it back to the literal ask.
+
+  This gate is a regression target. The pattern of expanding atomic requests scored 1.71 avg in session 42908b3f (2026-04-12) — the worst session on record. The original scope gate was insufficient; this revision adds the hard-block language and verification step.
 
 OUTPUT:
 
@@ -175,6 +207,20 @@ OUTPUT:
 OUTPUT:
 
 💪🏼 EFFORT LEVEL: [EFFORT LEVEL based on the reverse engineering step above] | [8 word reasoning]`
+
+**FAST-PATH CLASSIFIER (Standard tier only):** Run this decision tree at OBSERVE entry, before mode classification commits to full ceremony:
+
+| If the request matches... | Then... |
+|--------------------------|---------|
+| Atomic action (single discrete operation: create branch, rename file, answer one question) | Skip OBSERVE/THINK/PLAN/BUILD entirely. Write a 1-line ISC ("ISC-1: [action] completed and verified"), execute, verify, done. Skip LEARN reflection. |
+| Mechanical substitution (sed-style: replace string X with Y across N files, no judgment required) | Skip THINK/PLAN. Generate ISC enumerating each file. Execute via the appropriate tool (sed, batch Edit). Run VERIFY. |
+| Pure content extraction (pull section X from doc Y, list facts from URL Z) | Skip THINK/PLAN/BUILD. Single Read/Fetch + format. Run VERIFY. |
+| <=5 line single-file edit, no architectural decisions, no ambiguity | Skip THINK/PLAN. Read target, generate ISC, edit, verify. |
+| Anything that doesn't match the above | Use the full Algorithm path |
+
+The classifier is the gate, not the exception. If in doubt, prefer FAST-PATH for atomic and mechanical work — full ceremony on trivial work is the failure mode (12 reflection occurrences). Prior FAST-PATH guidance was prose-only; this is the concrete decision tree so the choice isn't left to in-the-moment judgment.
+
+**FAST-PATH does not skip verification.** ISC criteria still get written. VERIFY phase still runs. The classifier compresses ceremony, not correctness checks.
 
 - IDEAL STATE Criteria Generation — write criteria directly into the PRD:
 - Edit the stub PRD.md (already created at Algorithm entry) to add full content — update frontmatter `effort` field with the determined effort level, and add sections (Context, Criteria, Decisions, Verification) per `~/.pai/PAI/PRDFORMAT.md`
@@ -239,6 +285,11 @@ GUIDANCE:
 - Use /simplify after code changes to catch quality issues before VERIFY phase.
 - Use /batch for multi-file refactors or codebase-wide changes.
 
+**AGENT PROMPT REQUIREMENTS:** When delegating work to agents (via Agent tool, Task tool, or team agents), every prompt MUST include:
+1. **Explicit boundaries:** List the files/directories the agent should touch and, where relevant, what it should NOT touch. Unbounded exploration causes overlap and wasted work.
+2. **Exemplar excerpt:** Include a 10-20 line excerpt from existing output (code style, document format, naming conventions) so the agent matches the established pattern rather than inventing its own.
+3. **Schema/format constraints:** If the agent returns structured output, specify the exact format. If it writes files, specify the expected structure. Vague prompts produce inconsistent results.
+
 OUTPUT:
 
 🏹 CAPABILITIES SELECTED:
@@ -248,6 +299,15 @@ OUTPUT:
  🏹 [12-24 words on why only those CAPABILITIES were selected]
 
 - If any CAPABILITIES were selected for use in the OBSERVE phase, execute them now and update the ISC criteria in the PRD with the results
+
+- **OBSERVE EXIT GATE — EXTERNAL ASSUMPTION VERIFICATION (MANDATORY):** Before transitioning to THINK, every external assumption referenced in the ISC, plan, or proposed approach must be empirically verified, not inferred from memory. This is a hard block — do not exit OBSERVE until each item below is checked:
+  1. **File paths:** Every file/directory referenced in ISC must be confirmed to exist via Read or Bash `ls`. Do not assume a path is correct because it looks plausible.
+  2. **Repos/targets:** For multi-repo work (fork vs upstream, installed vs source, dotfiles vs yadm), confirm which copy is intended and verify it via `git remote -v` or `pwd`. The wrong-target failure mode is the second-most damaging on the system (avg rating 2.6).
+  3. **External endpoints / hostnames / APIs:** Probe with `curl -I`, `dig`, or equivalent before assuming an endpoint responds, exists, or behaves a certain way.
+  4. **Product specifics (versions, flags, command syntax):** Read official documentation. Do not infer command syntax or feature availability from memory or related products. Preference order: AI-enabled docs interface, web search, browser. If docs cannot be accessed, say so rather than guessing.
+  5. **Existing tooling:** Before improvising new code or queries, grep for existing utilities/skills/MCP tools that match the intended function. Do not write hand-rolled code that duplicates an existing helper.
+
+  Output a brief "OBSERVE EXIT CHECKS:" block listing each item verified and how. If any item cannot be verified, do not proceed — either resolve it or ask. This gate exists because prior verification rules were applied at the steering-rule level but the underlying pattern still produced 32 failure events across the dataset.
 
 EXAMPLES:
 
@@ -312,11 +372,38 @@ OUTPUT:
 
 [Prerequisite validation. Update ISC in PRD if necessary. Reanalyze CAPABILITIES to see if any need to be added.]
 
+- **DEPENDENCY ANALYSIS MICRO-PHASE (MANDATORY at all tiers):** Before exiting PLAN, enumerate every action in the execution plan — reads, writes, skill invocations, agent launches, long-running commands — into a flat list. For each action, identify its dependencies (what must complete first). Then partition into parallel tracks: any two actions that share no input get launched concurrently. Default disposition: **"if two actions share no input, launch them concurrently"** is the rule, not the exception.
+
+  **Exit gate:** No action may be executed serially if it has no dependency on a predecessor. If the BUILD/EXECUTE plan contains serialised actions with no inter-dependency, return to PLAN and re-partition. Write the dependency graph and the parallel tracks to the PRD's `### Plan` subsection.
+
+  **Common parallelisation candidates** (always batch unless dependencies prove otherwise):
+  - File reads where multiple files are needed → single message with N Read calls
+  - Independent agent launches → single message with N Agent calls
+  - Skill invocations on independent inputs → parallel Skill calls
+  - Verification checks against independent criteria → parallel Bash/Read calls
+  - Long downloads or builds vs unrelated planning/doc work
+
+  This micro-phase replaces the prior advisory rule. The earlier parallelization disposition saw the underlying signal grow from 11 to 14 occurrences over 21 days, demonstrating that disposition without mechanism is insufficient. The exit gate is the mechanism.
+
 - **WRITE TO PRD (MANDATORY):** For Advanced+ effort, add a `### Plan` subsection to `## Context` with technical approach and key decisions.
 
 ━━━ 🔨 BUILD ━━━ 4/7
 
 **FIRST ACTION:** Voice announce `"Entering the Build phase."`, then Edit PRD frontmatter `phase: build, updated: {timestamp}`. **INVOKE each selected capability via tool call.** Every skill: call via `Skill` tool. Every agent: call via `Task` tool. There is NO text-only alternative. Writing "**FirstPrinciples decomposition:**" without calling `Skill("FirstPrinciples")` is NOT invocation — it's theater. Every capability selected in OBSERVE MUST have a corresponding `Skill` or `Task` tool call in BUILD or EXECUTE.
+
+**PRE-READ SWEEP GATE (MANDATORY HARD BLOCK before EXECUTE):**
+Before EXECUTE begins, enumerate every file in the ISC's target list — every file that will be Read, Edited, or Written during EXECUTE. Then issue a SINGLE batched Read call with all of them as parallel tool invocations. This is one message with N Read tool calls, not N sequential messages. The gate is not satisfied by reading files one at a time as you go.
+
+**Hard block:** Edit and Write tools must not be invoked until the pre-read sweep completes for all enumerated targets. If you find yourself about to call Edit on a file you haven't already Read in this conversation, STOP — the gate has been bypassed. Return to BUILD, do the sweep, then proceed.
+
+**Purposes:**
+1. **Prevents "file has not been read" errors** — the Edit tool requires a prior Read in the same conversation. Serial read-edit-read-edit cycles waste ~1 round trip per file.
+2. **Confirms correct target directory** — verify you are operating on the intended location (repo source vs installed copy at `~/.claude/`, fork vs upstream). If the task involves both, explicitly note which files go where.
+3. **Forces dependency analysis** — enumerating targets up-front exposes batching opportunities.
+
+**Drift handling:** If the file list grows during EXECUTE (you discover a 9th file needs editing after the initial 8), pause EXECUTE, batch-read the new files, then resume. Do not edit-then-read.
+
+The prior pre-read rule was conceptual but the mechanical pattern persisted at 8 occurrences unchanged. This revision adds hard-block language and explicit batching requirement. Consider implementing as a tooling guard (Edit tool refuses until pre-read is verified) if the rule version still does not produce the behaviour by the next review cycle.
 
 - Any preparation that's required before execution.
 - **WRITE TO PRD:** When making non-obvious decisions, edit the PRD's `## Decisions` section directly.
@@ -339,6 +426,21 @@ OUTPUT:
 — For EACH IDEAL STATE criterion in the PRD, test that it's actually complete
 - For each criterion, edit the PRD: mark `- [x]` if not already, and add evidence to the `## Verification` section directly.
 - **Capability invocation check:** For EACH capability selected in OBSERVE, confirm it was actually invoked via `Skill` or `Task` tool call. Text output alone does NOT count. If any selected capability lacks a tool call, flag it as a failure.
+- **If a capability was selected but not invoked:** This is a CRITICAL FAILURE. Either (a) invoke it now if it would still add value, or (b) explicitly remove it from the selected list in the PRD with a reason. Leaving a phantom selection is dishonest. Add to ISC anti-criteria: `ISC-A: No phantom capabilities — every selected capability has a matching tool call`.
+
+- **OUTCOME VERIFICATION (MANDATORY):** Verification must confirm the deliverable actually works and matches the request, not just that files were modified:
+  - **Code changes:** Run the code or run tests. A file existing is not verification — it compiling/passing is.
+  - **Content changes:** Re-read the output and check it against ISC criteria. Confirm the content matches what was requested, not just that something was written.
+  - **Framework/tool choices:** If a framework or tool was selected during BUILD, verify it works with a minimal proof before scaling. A choice that fails at scale after bulk work is a verification failure.
+  - **Never claim "done" without outcome evidence.** "I wrote the file" is not done. "I wrote the file, read it back, and confirmed it contains X" is done. "Tests pass" is done. "Build succeeds" is done. The difference is between asserting completion and proving it.
+
+- **DOCUMENT LINT GATES (when the task touched documentation):** For any task that modified Markdown, MDX, or other document formats, run programmatic checks before exiting VERIFY:
+  - **Link checker:** verify every internal link resolves to an existing file/anchor and every external link returns a non-error status
+  - **Heading structure:** check heading hierarchy (no H1→H3 jumps), check anchor uniqueness
+  - **Frontmatter validation:** if files use frontmatter, verify required fields are present and values match the expected schema
+  - **Cross-doc consistency:** if multiple docs reference shared content (section names, function names, paths), diff them programmatically rather than reading both manually
+
+  Package these as reusable micro-tools (`Tools/lint-links.ts`, `Tools/lint-headings.ts`, `Tools/lint-frontmatter.ts`) so any document-editing task triggers them automatically. Manual multi-file reading missed these in 4 prior reflections.
 
 ━━━ 📚 LEARN ━━━ 7/7
 
@@ -358,7 +460,7 @@ OUTPUT:
 - **WRITE REFLECTION JSONL (MANDATORY for Standard+ effort):** After outputting the learning reflections above, append a structured JSONL entry to the reflections log. This feeds MineReflections, AlgorithmUpgrade, and Upgrade workflows.
 
 ```bash
-echo '{"timestamp":"[ISO-8601 with timezone]","effort_level":"[tier]","task_description":"[from TASK line]","criteria_count":[N],"criteria_passed":[N],"criteria_failed":[N],"prd_id":"[slug from PRD frontmatter]","implied_sentiment":[1-10 estimate of user satisfaction from conversation tone],"reflection_q1":"[Q1 answer - escape quotes]","reflection_q2":"[Q2 answer - escape quotes]","reflection_q3":"[Q3 answer from capabilities question - escape quotes]","within_budget":[true/false]}' >> ~/.pai/MEMORY/LEARNING/REFLECTIONS/algorithm-reflections.jsonl
+echo '{"timestamp":"[ISO-8601 with timezone]","effort_level":"[tier]","task_description":"[from TASK line]","criteria_count":[N],"criteria_passed":[N],"criteria_failed":[N],"prd_id":"[slug from PRD frontmatter]","implied_sentiment":[1-10 estimate of user satisfaction from conversation tone],"reflection_q1":"[Q1 answer - escape quotes]","reflection_q2":"[Q2 answer - escape quotes]","reflection_q3":"[Q3 answer from capabilities question - escape quotes]","within_budget":[true/false]}' >> ${PAI_DIR}/MEMORY/LEARNING/REFLECTIONS/algorithm-reflections.jsonl
 ```
 
 Fill in all bracketed values from the current session. `implied_sentiment` is your estimate of how satisfied the user is (1=frustrated, 10=delighted) based on conversation tone — do NOT read ratings.jsonl. Escape double quotes in reflection text with `\"`.
@@ -368,10 +470,10 @@ Fill in all bracketed values from the current session. `implied_sentiment` is yo
 ### Context Recovery
 
 If after compaction you don't know your current phase or criteria status:
-1. Read the most recent PRD from `~/.pai/MEMORY/WORK/` (by mtime) — it has all state
+1. Read the most recent PRD from `${PAI_DIR}/MEMORY/WORK/` (by mtime) — it has all state
 2. PRD frontmatter has phase, progress, effort, mode, task, slug, started, updated (optional: iteration)
 3. PRD body has criteria checkboxes, decisions, verification evidence
-4. `~/.pai/MEMORY/STATE/work.json` has the registry of all sessions (populated by read-only PRDSync + PRDStateSync hooks)
+4. `${PAI_DIR}/MEMORY/STATE/work.json` has the registry of all sessions (populated by read-only PRDSync + PRDStateSync hooks)
 
 ### PRD.md Format
 


### PR DESCRIPTION
## Summary

Sync reflection-mined runtime improvements from `~/.pai/PAI/Algorithm/v3.7.0.md` and `~/.claude/CLAUDE.md` into `Releases/v4.0.3+/.claude/`. The runtime had ~14KB of new Algorithm content since PR #101 that never reached the release tree — fresh installs were bootstrapping with an outdated Algorithm.

Closes #111.

## Algorithm v3.7.0.md (+117 / -15)

New sections brought in from runtime:
- **Voice mechanism rewrite** — inline curl replaced with self-gating `bun Notify.ts` CLI (subagent-safe, settings-aware)
- **Directive Compliance Gate** (NEW, before OBSERVE) — branch, target dir, user directives, sticky constraints
- **OBSERVE additions** — Request Comprehension Check, Context Disambiguation (TARGET DECLARATION), Scope Gate (HARD BLOCK)
- **FAST-PATH Classifier** decision table for Standard tier
- **Agent Prompt Requirements** (boundaries, exemplar, schema) in Capability Selection
- **OBSERVE Exit Gate** — External Assumption Verification (5 hard-block checks)
- **Dependency Analysis Micro-Phase** (MANDATORY) in PLAN
- **Pre-Read Sweep Gate** (MANDATORY HARD BLOCK before EXECUTE) in BUILD
- **VERIFY additions** — phantom-capability anti-criterion, OUTCOME VERIFICATION, DOCUMENT LINT GATES

### Fix-on-backport corrections

The runtime edits introduced four path regressions. The backport fixes them inline so they do not propagate to the release:
- `~/.claude/PAI/Tools/Notify.ts` → `~/.pai/PAI/Tools/Notify.ts` (×2)
- `~/.claude/PAI/PRDFORMAT.md` → `~/.pai/PAI/PRDFORMAT.md` (×2)

Also resolved the MINIMAL/ITERATION inconsistency:
- Critical Rules format list `(ALGORITHM, NATIVE, ITERATION, or MINIMAL)` → `(ALGORITHM or NATIVE)`
- MINIMAL is gone from CLAUDE.md (see below); ITERATION is a line modifier on NATIVE, not a standalone format

## CLAUDE.md (+15 / -20)

- Title de-versioned: `# PAI 4.0.3` → `# PAI`
- New `$PAI_DIR` preamble explaining the env-var convention
- Routing: `Greetings → MINIMAL` → `Greetings → None`
- Inline curl voice block removed from NATIVE MODE header (replaced by Notify.ts in the Algorithm)
- Speaker rename: `Assistant:` → `Viki:`
- Algorithm pointer: `PAI/Algorithm/v3.7.0.md` → `PAI/Algorithm/LATEST`
- Context Routing path uses new `PAI/` prefix convention
- `## MINIMAL — pure acknowledgments` block removed entirely
- `### Critical Rules (Zero Exceptions)` restored as proper header (runtime had orphaned the text onto the end of the ALGORITHM MODE paragraph — fixed on backport)
- Critical Rules format list matched to Algorithm: `(ALGORITHM or NATIVE)`

## Intentionally out of scope

Per #111's explicit scoping:
- Path tokenization sweep beyond the 4 named typos — see #108
- LATEST marker-vs-symlink paradigm decision — see #108
- `Tools/lint-*.ts` micro-tool scaffolding — punted per issue body
- **Ian's personal `@-imports`** (`@.claude/CLAUDE-USER.md`, `@.claude/marr/MARR-USER-CLAUDE.md`) at top of runtime CLAUDE.md — **NOT PAI-core content**. The release template must stay clean so fresh installs don't hit ENOENT on first session. Preservation is an installer responsibility — filed as follow-up:
  - **#126** — Installer: preserve user-added `@-imports` across install/upgrade
  - **#127** — Installer: pre-install CLAUDE.md conflict analysis

## Verification

- 34 ISCs + 5 anti-criteria all pass (PRD: `~/.pai/MEMORY/WORK/20260415-120000_issue-111-backport-algorithm-and-claudemd/PRD.md`)
- `grep 'claude/PAI/Tools/Notify\|claude/PAI/PRDFORMAT' Releases/v4.0.3+/.claude/PAI/Algorithm/v3.7.0.md` → 0
- `grep 'pai/PAI/Tools/Notify' <same>` → 2; `grep 'pai/PAI/PRDFORMAT' <same>` → 2
- `grep 'ITERATION, or MINIMAL' <same>` → 0
- CLAUDE.md: no `@.claude/` imports, no `Assistant:`, no `MINIMAL`, no `curl.*localhost:8888`, `(ALGORITHM or NATIVE)` = 1, `Viki:` = 1, `PAI/Algorithm/LATEST` = 3

## Test plan

- [ ] Read the updated `Releases/v4.0.3+/.claude/PAI/Algorithm/v3.7.0.md` — all 9 net-new sections (A-I) present
- [ ] Read the updated `Releases/v4.0.3+/.claude/CLAUDE.md` — template is clean (no personal imports), Critical Rules is a proper header, MINIMAL gone
- [ ] Dry-run an install against a clean `~/.claude/` — CLAUDE.md renders without import errors (verifies #126's rationale)
- [ ] Diff this PR against `~/.pai/PAI/Algorithm/v3.7.0.md` — only the 5 intentional corrections should differ