### PR TITLE
Fix residual .claude/PAI literals in skills tree (#116)

### DIFF
--- a/Packs/Media/src/Art/Tools/GeneratePrompt.ts
+++ b/Packs/Media/src/Art/Tools/GeneratePrompt.ts
@@ -67,10 +67,8 @@ interface PromptOutput {
 // Constants
 // ============================================================================
 
-const ART_AESTHETIC_PATH = resolve(
-  process.env.HOME!,
-  ".claude/PAI/Aesthetic.md"
-);
+const PAI_ROOT = process.env.PAI_DIR || resolve(process.env.HOME!, ".pai");
+const ART_AESTHETIC_PATH = resolve(PAI_ROOT, "PAI/Aesthetic.md");
 
 const COLOR_HEX_MAP: Record<TokyoNightColor, string> = {
   "Electric Blue": "#7aa2f7",

--- a/Packs/Telos/src/DashboardTemplate/App/api/chat/route.ts
+++ b/Packs/Telos/src/DashboardTemplate/App/api/chat/route.ts
@@ -30,7 +30,8 @@ When answering questions:
     // Use Inference tool instead of direct API
     const inferenceResult = await new Promise<{ success: boolean; output?: string; error?: string }>((resolve) => {
       const homeDir = process.env.HOME || ''
-      const proc = spawn('bun', ['run', `${homeDir}/.claude/PAI/Tools/Inference.ts`, '--level', 'fast', systemPrompt, message], {
+      const paiRoot = process.env.PAI_DIR || `${homeDir}/.pai`
+      const proc = spawn('bun', ['run', `${paiRoot}/PAI/Tools/Inference.ts`, '--level', 'fast', systemPrompt, message], {
         stdio: ['ignore', 'pipe', 'pipe'],
       })
 

--- a/Packs/Telos/src/DashboardTemplate/Lib/telos-data.ts
+++ b/Packs/Telos/src/DashboardTemplate/Lib/telos-data.ts
@@ -9,7 +9,8 @@ export interface TelosFile {
   type: 'markdown' | 'csv'
 }
 
-const TELOS_DIR = path.join(os.homedir(), '.claude/PAI/USER/TELOS')
+const PAI_ROOT = process.env.PAI_DIR || path.join(os.homedir(), '.pai')
+const TELOS_DIR = path.join(PAI_ROOT, 'PAI/USER/TELOS')
 
 export function getAllTelosData(): TelosFile[] {
   const files: TelosFile[] = []

--- a/Releases/v4.0.3+/.claude/skills/Agents/Tools/ComposeAgent.ts
+++ b/Releases/v4.0.3+/.claude/skills/Agents/Tools/ComposeAgent.ts
@@ -35,7 +35,7 @@ import Handlebars from "handlebars";
 // Paths
 const HOME = process.env.HOME || "~";
 const BASE_TRAITS_PATH = `${HOME}/.claude/skills/Agents/Data/Traits.yaml`;
-const USER_TRAITS_PATH = `${HOME}/.claude/PAI/USER/SKILLCUSTOMIZATIONS/Agents/Traits.yaml`;
+const USER_TRAITS_PATH = `${HOME}/.pai/PAI/USER/SKILLCUSTOMIZATIONS/Agents/Traits.yaml`;
 const TEMPLATE_PATH = `${HOME}/.claude/skills/Agents/Templates/DynamicAgent.hbs`;
 const CUSTOM_AGENTS_DIR = `${HOME}/.claude/custom-agents`;
 

--- a/Releases/v4.0.3+/.claude/skills/Media/Art/Tools/GeneratePrompt.ts
+++ b/Releases/v4.0.3+/.claude/skills/Media/Art/Tools/GeneratePrompt.ts
@@ -67,10 +67,8 @@ interface PromptOutput {
 // Constants
 // ============================================================================
 
-const ART_AESTHETIC_PATH = resolve(
-  process.env.HOME!,
-  ".claude/PAI/Aesthetic.md"
-);
+const PAI_ROOT = process.env.PAI_DIR || resolve(process.env.HOME!, ".pai");
+const ART_AESTHETIC_PATH = resolve(PAI_ROOT, "PAI/Aesthetic.md");
 
 const COLOR_HEX_MAP: Record<TokyoNightColor, string> = {
   "Electric Blue": "#7aa2f7",

--- a/Releases/v4.0.3+/.claude/skills/Telos/DashboardTemplate/App/api/chat/route.ts
+++ b/Releases/v4.0.3+/.claude/skills/Telos/DashboardTemplate/App/api/chat/route.ts
@@ -30,7 +30,8 @@ When answering questions:
     // Use Inference tool instead of direct API
     const inferenceResult = await new Promise<{ success: boolean; output?: string; error?: string }>((resolve) => {
       const homeDir = process.env.HOME || ''
-      const proc = spawn('bun', ['run', `${homeDir}/.claude/PAI/Tools/Inference.ts`, '--level', 'fast', systemPrompt, message], {
+      const paiRoot = process.env.PAI_DIR || `${homeDir}/.pai`
+      const proc = spawn('bun', ['run', `${paiRoot}/PAI/Tools/Inference.ts`, '--level', 'fast', systemPrompt, message], {
         stdio: ['ignore', 'pipe', 'pipe'],
       })
 

--- a/Releases/v4.0.3+/.claude/skills/Telos/DashboardTemplate/Lib/telos-data.ts
+++ b/Releases/v4.0.3+/.claude/skills/Telos/DashboardTemplate/Lib/telos-data.ts
@@ -9,7 +9,8 @@ export interface TelosFile {
   type: 'markdown' | 'csv'
 }
 
-const TELOS_DIR = path.join(os.homedir(), '.claude/PAI/USER/TELOS')
+const PAI_ROOT = process.env.PAI_DIR || path.join(os.homedir(), '.pai')
+const TELOS_DIR = path.join(PAI_ROOT, 'PAI/USER/TELOS')
 
 export function getAllTelosData(): TelosFile[] {
   const files: TelosFile[] = []


### PR DESCRIPTION
## Summary

- Replaces 4 hardcoded \`~/.claude/PAI/\` literals in \`Releases/v4.0.3+/.claude/skills/\` with \`PAI_DIR\`-aware paths rooted at \`~/.pai/\`, so the skills tree stops breaking on fresh post-PR #101 installs.
- Fixes the 3 corresponding parallels in \`Packs/\` (source-of-truth). Sync direction is Packs→Releases (confirmed — see below), so a Releases-only fix would be reverted on the next sync.
- Surfaced two follow-up issues during verification: #129 and #130.

Fixes #116.

## The 7 changed files

**Releases/ (4 — per issue scope):**
- \`Releases/v4.0.3+/.claude/skills/Telos/DashboardTemplate/Lib/telos-data.ts:12\`
- \`Releases/v4.0.3+/.claude/skills/Telos/DashboardTemplate/App/api/chat/route.ts:33\`
- \`Releases/v4.0.3+/.claude/skills/Agents/Tools/ComposeAgent.ts:38\`
- \`Releases/v4.0.3+/.claude/skills/Media/Art/Tools/GeneratePrompt.ts:72\`

**Packs/ (3 parallels — source-of-truth):**
- \`Packs/Telos/src/DashboardTemplate/Lib/telos-data.ts:12\`
- \`Packs/Telos/src/DashboardTemplate/App/api/chat/route.ts:33\`
- \`Packs/Media/src/Art/Tools/GeneratePrompt.ts:72\`

(\`Packs/Agents/src/Tools/ComposeAgent.ts:38\` was already fixed — no Packs edit needed for ComposeAgent.)

## Sync-direction investigation

Issue #116's body explicitly asked whether Packs/ parallels needed fixing. Checked, and the answer is **yes**:

- \`Packs/Agents/src/Tools/ComposeAgent.ts:38\` already contains the fix (\`\${HOME}/.pai/PAI/USER/SKILLCUSTOMIZATIONS/…\`)
- \`Releases/v4.0.3+/.claude/skills/Agents/Tools/ComposeAgent.ts:38\` was still stale

That divergence only makes sense if Packs is source-of-truth and Releases is a downstream artifact. Without the 3 Packs parallel fixes, the next Packs→Releases sync would silently reintroduce 3 of the 4 bugs.

## Convention chosen

Used \`process.env.PAI_DIR || <HOME>/.pai\` for the 3 new fixes (telos-data.ts, route.ts, GeneratePrompt.ts × 2), matching the pattern already in \`Releases/v4.0.3+/.claude/PAI/Tools/RebuildPAI.ts:16\`, \`GetCounts.ts:44\`, and \`ACTIONS/lib/runner.v2.ts:32\`.

For \`ComposeAgent.ts:38\` specifically, matched the already-fixed Packs pattern (hardcoded \`\${HOME}/.pai/…\`) byte-for-byte rather than introducing a PAI_DIR-aware variant. This keeps Packs and Releases byte-identical on that line so neither side of the sync wins/loses the edit later.

Note: Issue #116's body cited \`algorithm.ts\` and \`FailureCapture.ts\` as examples of the correct convention. That's inaccurate — those two files still use the \`.claude\` fallback. The actually-correct examples are \`RebuildPAI.ts\`, \`GetCounts.ts\`, and \`runner.v2.ts\`. Logged this in #130 for follow-up.

## Follow-ups filed during verification

- **#129** — \`Releases/v4.0.3+/.claude/skills/Agents/Tools/ComposeAgent.ts\` lines 37/39 still reference \`~/.claude/skills/\` while the Packs parallel has already migrated them. Same bug class as #116, different literal prefix.
- **#130** — 9 files (\`algorithm.ts\`, \`FailureCapture.ts\`, \`OpinionTracker.ts\`, \`RelationshipReflect.ts\`, \`WisdomCrossFrameSynthesizer.ts\`, \`WisdomDomainClassifier.ts\`, \`WisdomFrameUpdater.ts\`, \`Packs/Media/src/Art/Tools/Generate.ts\`, \`GenerateMidjourneyImage.ts\`) use \`process.env.PAI_DIR || <HOME>/.claude\` as their fallback — convention drift to clean up.

## Out of scope (intentionally not touched)

- \`Releases/.../ComposeAgent.ts\` lines 37, 39, 40 (\`.claude/skills/\`, \`.claude/custom-agents\`) — different bug class, filed as #129
- \`algorithm.ts\`, \`FailureCapture.ts\`, etc. \`.claude\`-fallback drift — different bug class, filed as #130
- \`Packs/*/INSTALL.md\` backward-compat \`~/.claude/PAI\` guards — different code path (migration checks)
- Comment/help-text references to \`~/.claude/custom-agents\` in ComposeAgent.ts — deferred to #129's decision on custom-agents location

## Test plan

- [x] \`grep -rn '\\.claude/PAI' Releases/v4.0.3+/.claude/skills/\` returns 0 hits
- [x] \`grep -rn '\\.claude/PAI' Packs/Telos/src Packs/Media/src Packs/Agents/src\` returns 0 hits
- [x] All 7 edited \`.ts\` files parse without syntax errors (\`bun build --target=node --external='*'\`)
- [x] \`diff\` between \`Releases/.../ComposeAgent.ts:38\` and \`Packs/Agents/src/.../ComposeAgent.ts:38\` is empty (byte-identical)
- [x] \`git status\` shows exactly the 7 intended files modified
- [ ] Optional runtime check: launch Telos dashboard on a machine where \`~/.claude/PAI/\` doesn't exist and confirm \`TELOS_DIR\` resolves + the chat route spawns \`Inference.ts\` correctly (I haven't run this — my dev box still has the legacy \`~/.claude/PAI/\` directory so it wouldn't surface the original bug anyway)

🤖 Generated with [Claude Code](https://claude.com/claude-code)