### PR TITLE
Fix .claude/skills literals in Releases ComposeAgent.ts (#129)

### DIFF
--- a/Releases/v4.0.3+/.claude/skills/Agents/Tools/ComposeAgent.ts
+++ b/Releases/v4.0.3+/.claude/skills/Agents/Tools/ComposeAgent.ts
@@ -34,9 +34,9 @@ import Handlebars from "handlebars";
 
 // Paths
 const HOME = process.env.HOME || "~";
-const BASE_TRAITS_PATH = `${HOME}/.claude/skills/Agents/Data/Traits.yaml`;
+const BASE_TRAITS_PATH = `${HOME}/.pai/skills/Agents/Data/Traits.yaml`;
 const USER_TRAITS_PATH = `${HOME}/.pai/PAI/USER/SKILLCUSTOMIZATIONS/Agents/Traits.yaml`;
-const TEMPLATE_PATH = `${HOME}/.claude/skills/Agents/Templates/DynamicAgent.hbs`;
+const TEMPLATE_PATH = `${HOME}/.pai/skills/Agents/Templates/DynamicAgent.hbs`;
 const CUSTOM_AGENTS_DIR = `${HOME}/.claude/custom-agents`;
 
 // Types


### PR DESCRIPTION
Closes #129.

## Summary
- Mirror already-fixed `Packs/Agents/src/Tools/ComposeAgent.ts` into the `Releases/v4.0.3+/` snapshot for lines 37 and 39 of `ComposeAgent.ts` (`BASE_TRAITS_PATH`, `TEMPLATE_PATH`).
- Changes `~/.claude/skills/...` → `~/.pai/skills/...` — the two-root convention Packs/ already uses.
- No Packs/ edit required; Packs was already correct. No runtime modifications.

## Out of scope
- Line 40 (`~/.claude/custom-agents`) and help-text references are intentionally untouched pending the custom-agents location decision (see issue).

## Test plan
- [x] `grep -n '\.claude/skills' Releases/v4.0.3+/.claude/skills/Agents/Tools/ComposeAgent.ts` returns zero hits
- [x] Diff is exactly the 2 lines prescribed in #129
- [x] Releases lines 37/39 now byte-match Packs lines 37/39

🤖 Generated with [Claude Code](https://claude.com/claude-code)