### PR TITLE
Fix PAI_DIR fallback drift: 9 files fall back to .pai (#130)

### DIFF
--- a/Packs/Media/src/Art/Tools/Generate.ts
+++ b/Packs/Media/src/Art/Tools/Generate.ts
@@ -27,7 +27,7 @@ import { extname, resolve } from "node:path";
  * This ensures API keys are available regardless of how the CLI is invoked
  */
 async function loadEnv(): Promise<void> {
-  const paiDir = process.env.PAI_DIR || resolve(process.env.HOME!, '.claude');
+  const paiDir = process.env.PAI_DIR || resolve(process.env.HOME!, '.pai');
   const envPath = resolve(paiDir, '.env');
   try {
     const envContent = await readFile(envPath, 'utf-8');
@@ -188,7 +188,7 @@ async function detectMimeType(filePath: string): Promise<string> {
 // ============================================================================
 
 // PAI directory for documentation paths
-const PAI_DIR = process.env.PAI_DIR || `${process.env.HOME}/.claude`;
+const PAI_DIR = process.env.PAI_DIR || `${process.env.HOME}/.pai`;
 
 function showHelp(): void {
   console.log(`

--- a/Packs/Media/src/Art/Tools/GenerateMidjourneyImage.ts
+++ b/Packs/Media/src/Art/Tools/GenerateMidjourneyImage.ts
@@ -26,7 +26,7 @@ import { resolve } from 'node:path';
  * This ensures API keys are available regardless of how the CLI is invoked
  */
 async function loadEnv(): Promise<void> {
-  const paiDir = process.env.PAI_DIR || resolve(process.env.HOME!, '.claude');
+  const paiDir = process.env.PAI_DIR || resolve(process.env.HOME!, '.pai');
   const envPath = resolve(paiDir, '.env');
   try {
     const envContent = await readFile(envPath, 'utf-8');

--- a/Releases/v4.0.3+/.claude/PAI/Tools/FailureCapture.ts
+++ b/Releases/v4.0.3+/.claude/PAI/Tools/FailureCapture.ts
@@ -29,7 +29,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync } from
 import { join, basename } from 'path';
 import { inference } from './Inference';
 
-const PAI_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const PAI_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.pai');
 
 interface FailureCaptureInput {
   transcriptPath: string;

--- a/Releases/v4.0.3+/.claude/PAI/Tools/OpinionTracker.ts
+++ b/Releases/v4.0.3+/.claude/PAI/Tools/OpinionTracker.ts
@@ -24,7 +24,7 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
 import { join } from 'path';
 
-const PAI_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const PAI_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.pai');
 const OPINIONS_FILE = join(PAI_DIR, 'PAI/USER/OPINIONS.md');
 const RELATIONSHIP_LOG = join(PAI_DIR, 'MEMORY/RELATIONSHIP');
 

--- a/Releases/v4.0.3+/.claude/PAI/Tools/RelationshipReflect.ts
+++ b/Releases/v4.0.3+/.claude/PAI/Tools/RelationshipReflect.ts
@@ -29,7 +29,7 @@ import { readFileSync, writeFileSync, existsSync, readdirSync, mkdirSync } from 
 import { join } from 'path';
 import { execFileSync } from 'child_process';
 
-const PAI_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const PAI_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.pai');
 
 interface RelationshipNote {
   type: 'W' | 'B' | 'O';

--- a/Releases/v4.0.3+/.claude/PAI/Tools/WisdomCrossFrameSynthesizer.ts
+++ b/Releases/v4.0.3+/.claude/PAI/Tools/WisdomCrossFrameSynthesizer.ts
@@ -18,7 +18,7 @@ import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync } from 
 import { join, basename } from 'path';
 import { parseArgs } from 'util';
 
-const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.pai');
 const WISDOM_DIR = join(BASE_DIR, 'MEMORY', 'WISDOM');
 const FRAMES_DIR = join(WISDOM_DIR, 'FRAMES');
 const PRINCIPLES_DIR = join(WISDOM_DIR, 'PRINCIPLES');

--- a/Releases/v4.0.3+/.claude/PAI/Tools/WisdomDomainClassifier.ts
+++ b/Releases/v4.0.3+/.claude/PAI/Tools/WisdomDomainClassifier.ts
@@ -17,7 +17,7 @@ import { existsSync, readdirSync, readFileSync } from 'fs';
 import { join, basename } from 'path';
 import { parseArgs } from 'util';
 
-const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.pai');
 const FRAMES_DIR = join(BASE_DIR, 'MEMORY', 'WISDOM', 'FRAMES');
 
 // ── Domain Keyword Map ──

--- a/Releases/v4.0.3+/.claude/PAI/Tools/WisdomFrameUpdater.ts
+++ b/Releases/v4.0.3+/.claude/PAI/Tools/WisdomFrameUpdater.ts
@@ -19,7 +19,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { parseArgs } from 'util';
 
-const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.pai');
 const FRAMES_DIR = join(BASE_DIR, 'MEMORY', 'WISDOM', 'FRAMES');
 
 // ── Types ──

--- a/Releases/v4.0.3+/.claude/PAI/Tools/algorithm.ts
+++ b/Releases/v4.0.3+/.claude/PAI/Tools/algorithm.ts
@@ -46,7 +46,7 @@ import { generatePRDTemplate } from "../../hooks/lib/prd-template";
 // ─── Paths ───────────────────────────────────────────────────────────────────
 
 const HOME = process.env.HOME || "~";
-const BASE_DIR = process.env.PAI_DIR || join(HOME, ".claude");
+const BASE_DIR = process.env.PAI_DIR || join(HOME, ".pai");
 const ALGORITHMS_DIR = join(BASE_DIR, "MEMORY", "STATE", "algorithms");
 const SESSION_NAMES_PATH = join(BASE_DIR, "MEMORY", "STATE", "session-names.json");
 const PROJECTS_DIR = process.env.PROJECTS_DIR || join(HOME, "Projects");


### PR DESCRIPTION
Closes #130.

## Summary
- Swaps `process.env.PAI_DIR || ~/.claude` → `process.env.PAI_DIR || ~/.pai` on 10 lines across 9 files, matching the canonical convention (`RebuildPAI.ts:16`, `GetCounts.ts:44`, `ACTIONS/lib/runner.v2.ts:32`).
- Silent-failure case only — does not change behavior when `\$PAI_DIR` is set (the common case). Fixes installs where the env var is unset and `~/.claude/PAI/` has been cleaned up.
- Local identifier names (`PAI_DIR`, `BASE_DIR`, `paiDir`) preserved per issue spec.

## Empirical finding re: Packs parallels
The issue's body speculates the 7 `Releases/v4.0.3+/.claude/PAI/Tools/` files "likely have Packs parallels that need the same fix." **They don't.** Verified via `find Packs -name "X.ts"` for each of the 7 filenames → zero results. These files are released-tree-canonical (they live in `Releases/` without a Packs source) so there's no sync-overwrite risk and no parallel edits needed. The 10-line scope in the issue is the complete scope.

## Files (9 files, 10 lines)
- `Packs/Media/src/Art/Tools/Generate.ts` — lines 30, 191
- `Packs/Media/src/Art/Tools/GenerateMidjourneyImage.ts` — line 29
- `Releases/v4.0.3+/.claude/PAI/Tools/algorithm.ts` — line 49
- `Releases/v4.0.3+/.claude/PAI/Tools/FailureCapture.ts` — line 32
- `Releases/v4.0.3+/.claude/PAI/Tools/OpinionTracker.ts` — line 27
- `Releases/v4.0.3+/.claude/PAI/Tools/RelationshipReflect.ts` — line 32
- `Releases/v4.0.3+/.claude/PAI/Tools/WisdomCrossFrameSynthesizer.ts` — line 21
- `Releases/v4.0.3+/.claude/PAI/Tools/WisdomDomainClassifier.ts` — line 20
- `Releases/v4.0.3+/.claude/PAI/Tools/WisdomFrameUpdater.ts` — line 22

## Out of scope
- Comment/help-text references to `~/.claude/` (not executable paths)
- Line 40 `custom-agents` in ComposeAgent.ts (tracked in #129 discussion — location decision needed)
- The #116 body's inaccurate citation of `algorithm.ts`/`FailureCapture.ts` as canonical examples — the fact is corrected by this PR (they now use the canonical convention) but the #116 body itself is historical and not worth editing

## Test plan
- [x] \`grep -rn \"process\\.env\\.PAI_DIR.*\\.claude\" Packs/ Releases/v4.0.3+/.claude/PAI/\` returns zero hits
- [x] \`git diff\` shows exactly 10 line changes across 9 files
- [x] No comment/help-text lines modified
- [x] No files outside the enumerated set modified
- [x] Identifier names (\`PAI_DIR\`, \`BASE_DIR\`, \`paiDir\`) preserved in each file
- [ ] Behavior when \`\$PAI_DIR\` is set: unchanged (not regression-testable without an install scaffold, but the OR short-circuit semantics are trivially preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)