### PR TITLE
Preserve user CLAUDE.md @-imports + safety backup on rebuild (#126, #127)

### DIFF
--- a/Releases/v4.0.3+/.claude/PAI/Tools/BuildCLAUDE.ts
+++ b/Releases/v4.0.3+/.claude/PAI/Tools/BuildCLAUDE.ts
@@ -14,6 +14,7 @@
 
 import { readFileSync, writeFileSync, existsSync } from "fs";
 import { join } from "path";
+import { applyPreservation } from "./preserve-claudemd";
 
 const PAI_DIR = join(process.env.HOME!, ".claude");
 const TEMPLATE_PATH = join(PAI_DIR, "CLAUDE.md.template");
@@ -97,15 +98,19 @@ export function build(): { rebuilt: boolean; reason?: string } {
     content = content.replaceAll(key, value);
   }
 
-  // Check if output already matches
-  if (existsSync(OUTPUT_PATH)) {
-    const existing = readFileSync(OUTPUT_PATH, "utf-8");
-    if (existing === content) {
-      return { rebuilt: false, reason: "CLAUDE.md already current" };
-    }
+  // Preserve user @-imports and take a safety backup before overwrite (#126, #127).
+  const { finalContent, unchanged, log } = applyPreservation({
+    existingPath: OUTPUT_PATH,
+    newContent: content,
+    rootDir: PAI_DIR,
+  });
+  for (const line of log) console.error(line);
+
+  if (unchanged) {
+    return { rebuilt: false, reason: "CLAUDE.md already current" };
   }
 
-  writeFileSync(OUTPUT_PATH, content);
+  writeFileSync(OUTPUT_PATH, finalContent);
   return { rebuilt: true };
 }
 

--- a/Releases/v4.0.3+/.claude/PAI/Tools/preserve-claudemd.test.ts
+++ b/Releases/v4.0.3+/.claude/PAI/Tools/preserve-claudemd.test.ts
@@ -1,0 +1,242 @@
+/**
+ * preserve-claudemd.test.ts — Bun tests for CLAUDE.md preservation logic.
+ *
+ * Run: bun test preserve-claudemd.test.ts
+ *
+ * Uses a throwaway tmp root per test so nothing touches the real ~/.claude.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  applyPreservation,
+  backupIfDiffers,
+  extractUserImports,
+  filterResolvableImports,
+  injectImportsAbovePaiHeading,
+} from "./preserve-claudemd";
+
+const TEMPLATE = `# PAI {{PAI_VERSION}} — Personal AI Infrastructure
+
+# MODES
+
+Everything else.
+`;
+
+let root: string;
+let claudeMd: string;
+
+beforeEach(() => {
+  root = join(tmpdir(), `preserve-claudemd-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(root, { recursive: true });
+  claudeMd = join(root, "CLAUDE.md");
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("extractUserImports", () => {
+  test("pulls a single @-import from the top", () => {
+    const content = `@.claude/CLAUDE-USER.md\n\n# PAI 4.0.3\n\nbody`;
+    expect(extractUserImports(content)).toEqual(["@.claude/CLAUDE-USER.md"]);
+  });
+
+  test("stops at the first heading", () => {
+    const content = `@a.md\n\n# PAI\n@b.md\n`;
+    expect(extractUserImports(content)).toEqual(["@a.md"]);
+  });
+
+  test("returns empty when there are no imports", () => {
+    expect(extractUserImports(TEMPLATE)).toEqual([]);
+  });
+
+  test("handles multiple imports in order", () => {
+    const content = `@x.md\n@y.md\n@z.md\n\n# PAI\n`;
+    expect(extractUserImports(content)).toEqual(["@x.md", "@y.md", "@z.md"]);
+  });
+});
+
+describe("injectImportsAbovePaiHeading", () => {
+  test("no imports = template verbatim", () => {
+    expect(injectImportsAbovePaiHeading(TEMPLATE, [])).toBe(TEMPLATE);
+  });
+
+  test("inserts imports above # PAI", () => {
+    const out = injectImportsAbovePaiHeading(TEMPLATE, ["@user.md"]);
+    expect(out.startsWith("@user.md\n\n# PAI")).toBe(true);
+    expect(out).toContain("# MODES");
+  });
+
+  test("preserves multiple imports in order", () => {
+    const out = injectImportsAbovePaiHeading(TEMPLATE, ["@a.md", "@b.md"]);
+    expect(out.startsWith("@a.md\n@b.md\n\n# PAI")).toBe(true);
+  });
+});
+
+describe("filterResolvableImports", () => {
+  test("keeps imports whose target exists", () => {
+    writeFileSync(join(root, "exists.md"), "x");
+    const result = filterResolvableImports(["@exists.md"], root);
+    expect(result.kept).toEqual(["@exists.md"]);
+    expect(result.dropped).toEqual([]);
+  });
+
+  test("drops imports whose target is missing", () => {
+    const result = filterResolvableImports(["@missing.md"], root);
+    expect(result.kept).toEqual([]);
+    expect(result.dropped).toEqual(["@missing.md"]);
+  });
+
+  test("resolves nested paths relative to rootDir", () => {
+    mkdirSync(join(root, ".claude"), { recursive: true });
+    writeFileSync(join(root, ".claude", "user.md"), "x");
+    const result = filterResolvableImports(["@.claude/user.md"], root);
+    expect(result.kept).toEqual(["@.claude/user.md"]);
+  });
+
+  test("resolves Claude Code HOME-relative imports (the real ~/.claude/CLAUDE.md case)", () => {
+    // Real case: rootDir = ~/.claude, import @.claude/foo.md, file at ~/.claude/foo.md.
+    // Under tmp: root = HOME-proxy, claudeDir = .claude subdir, file directly inside it.
+    const claudeDir = join(root, ".claude");
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(join(claudeDir, "user-config.md"), "x");
+    // rootDir is the .claude dir; resolver should try parentDir (root) + ".claude/user-config.md".
+    const result = filterResolvableImports(["@.claude/user-config.md"], claudeDir);
+    expect(result.kept).toEqual(["@.claude/user-config.md"]);
+  });
+});
+
+describe("backupIfDiffers", () => {
+  test("no backup when content is identical", () => {
+    writeFileSync(claudeMd, "same\n");
+    const result = backupIfDiffers(claudeMd, "same\n", "same\n");
+    expect(result.backupPath).toBeNull();
+    expect(result.diff).toBeNull();
+  });
+
+  test("writes backup with old bytes when content differs", () => {
+    const result = backupIfDiffers(claudeMd, "old line\n", "new line\n");
+    expect(result.backupPath).not.toBeNull();
+    expect(existsSync(result.backupPath!)).toBe(true);
+    expect(readFileSync(result.backupPath!, "utf-8")).toBe("old line\n");
+    expect(result.diff).toEqual({ added: 1, removed: 1 });
+  });
+
+  test("backup filename includes millisecond precision", () => {
+    const result = backupIfDiffers(claudeMd, "old\n", "new\n");
+    expect(result.backupPath).toMatch(/CLAUDE\.md\.bak\.\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z$/);
+  });
+});
+
+describe("applyPreservation", () => {
+  test("fresh install (no pre-existing file) → no preservation, no backup, unchanged false", () => {
+    const result = applyPreservation({
+      existingPath: claudeMd,
+      newContent: TEMPLATE,
+      rootDir: root,
+    });
+    expect(result.finalContent).toBe(TEMPLATE);
+    expect(result.unchanged).toBe(false);
+    expect(result.log).toEqual([]);
+    expect(readdirSync(root).filter((f) => f.startsWith("CLAUDE.md.bak"))).toEqual([]);
+  });
+
+  test("no imports + content identical → unchanged flag set, no backup, no log noise", () => {
+    writeFileSync(claudeMd, TEMPLATE);
+    const result = applyPreservation({
+      existingPath: claudeMd,
+      newContent: TEMPLATE,
+      rootDir: root,
+    });
+    expect(result.finalContent).toBe(TEMPLATE);
+    expect(result.unchanged).toBe(true);
+    expect(result.log).toEqual([]);
+  });
+
+  test("resolvable user import → preserved above # PAI heading", () => {
+    writeFileSync(join(root, "custom.md"), "x");
+    writeFileSync(claudeMd, `@custom.md\n\n# PAI 4.0.2\n\nold body\n`);
+    const result = applyPreservation({
+      existingPath: claudeMd,
+      newContent: TEMPLATE,
+      rootDir: root,
+    });
+    expect(result.finalContent.startsWith("@custom.md\n\n# PAI")).toBe(true);
+    expect(result.log.some((l) => l.includes("preserved 1, dropped 0"))).toBe(true);
+  });
+
+  test("dangling user import → dropped with log", () => {
+    writeFileSync(claudeMd, `@ghost.md\n\n# PAI 4.0.2\n`);
+    const result = applyPreservation({
+      existingPath: claudeMd,
+      newContent: TEMPLATE,
+      rootDir: root,
+    });
+    expect(result.finalContent).not.toContain("@ghost.md");
+    expect(result.log.some((l) => l.includes("preserved 0, dropped 1"))).toBe(true);
+    expect(result.log.some((l) => l.includes("dropped broken import: @ghost.md"))).toBe(true);
+  });
+
+  test("mix of resolvable + dangling → only resolvable preserved", () => {
+    writeFileSync(join(root, "real.md"), "x");
+    writeFileSync(claudeMd, `@real.md\n@ghost.md\n\n# PAI 4.0.2\n`);
+    const result = applyPreservation({
+      existingPath: claudeMd,
+      newContent: TEMPLATE,
+      rootDir: root,
+    });
+    expect(result.finalContent).toContain("@real.md");
+    expect(result.finalContent).not.toContain("@ghost.md");
+    expect(result.log.some((l) => l.includes("preserved 1, dropped 1"))).toBe(true);
+  });
+
+  test("content change triggers backup + drift log", () => {
+    writeFileSync(claudeMd, `# PAI 4.0.2\n\nold body\n`);
+    const result = applyPreservation({
+      existingPath: claudeMd,
+      newContent: TEMPLATE,
+      rootDir: root,
+    });
+    const hasBackupLog = result.log.some((l) => l.startsWith("[preserve-claudemd] backup:"));
+    const hasDriftLog = result.log.some((l) => l.startsWith("[preserve-claudemd] drift:"));
+    expect(hasBackupLog).toBe(true);
+    expect(hasDriftLog).toBe(true);
+    const backups = readdirSync(root).filter((f) => f.startsWith("CLAUDE.md.bak"));
+    expect(backups.length).toBe(1);
+  });
+
+  test("identical content after preservation → unchanged true, no backup", () => {
+    writeFileSync(claudeMd, TEMPLATE);
+    const result = applyPreservation({
+      existingPath: claudeMd,
+      newContent: TEMPLATE,
+      rootDir: root,
+    });
+    expect(result.unchanged).toBe(true);
+    const backups = readdirSync(root).filter((f) => f.startsWith("CLAUDE.md.bak"));
+    expect(backups.length).toBe(0);
+    expect(result.log).toEqual([]);
+  });
+
+  test("preserved import survives second rebuild (idempotence)", () => {
+    writeFileSync(join(root, "custom.md"), "x");
+    writeFileSync(claudeMd, `@custom.md\n\n# PAI 4.0.2\n\nold\n`);
+
+    const first = applyPreservation({
+      existingPath: claudeMd,
+      newContent: TEMPLATE,
+      rootDir: root,
+    });
+    writeFileSync(claudeMd, first.finalContent);
+
+    const second = applyPreservation({
+      existingPath: claudeMd,
+      newContent: TEMPLATE,
+      rootDir: root,
+    });
+    expect(second.finalContent.startsWith("@custom.md\n\n# PAI")).toBe(true);
+  });
+});

--- a/Releases/v4.0.3+/.claude/PAI/Tools/preserve-claudemd.ts
+++ b/Releases/v4.0.3+/.claude/PAI/Tools/preserve-claudemd.ts
@@ -1,0 +1,164 @@
+/**
+ * preserve-claudemd.ts — protect user edits to ~/.claude/CLAUDE.md across rebuilds.
+ *
+ * Called by BuildCLAUDE.build() on every rebuild (install, upgrade, SessionStart hook).
+ *
+ * Fixes:
+ *   - #126: user-added @-imports at top of CLAUDE.md are re-injected into the new output
+ *   - #127 (minimal): non-identical overwrites take a timestamped backup + log drift summary
+ *
+ * The release template ships import-free (see #111), so every @-import found in the
+ * existing CLAUDE.md is by definition user-added — no in-tree/out-of-tree classifier needed.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { dirname, isAbsolute, resolve } from "path";
+
+const IMPORT_LINE = /^@\S+$/;
+const PAI_HEADING = /^#\s+PAI\b/m;
+const LOG_PREFIX = "[preserve-claudemd]";
+
+/**
+ * Extract @-import lines from the top of CLAUDE.md, stopping at the first `#` heading.
+ * Blank lines between imports are allowed and not returned.
+ */
+export function extractUserImports(content: string): string[] {
+  const lines = content.split("\n");
+  const imports: string[] = [];
+  for (const line of lines) {
+    if (line.startsWith("#")) break;
+    if (IMPORT_LINE.test(line)) imports.push(line);
+  }
+  return imports;
+}
+
+/**
+ * Splice import lines immediately above the first `# PAI` heading in `template`.
+ * No-op if no imports or no PAI heading is found.
+ */
+export function injectImportsAbovePaiHeading(
+  template: string,
+  imports: string[]
+): string {
+  if (imports.length === 0) return template;
+  const match = template.match(PAI_HEADING);
+  if (!match || match.index === undefined) return template;
+
+  const before = template.slice(0, match.index).trimEnd();
+  const after = template.slice(match.index);
+  const prefix = before ? `${before}\n\n` : "";
+  return `${imports.join("\n")}\n\n${prefix}${after}`;
+}
+
+/**
+ * Resolve each import's target path and keep only the ones that exist.
+ *
+ * Claude Code resolves `@path` with some tolerance: a path like `@.claude/foo.md` found
+ * inside `~/.claude/CLAUDE.md` resolves to `~/.claude/foo.md` (HOME + path), not to
+ * `~/.claude/.claude/foo.md` (rootDir + path). We try both candidates so either semantics
+ * works — an import is kept if ANY candidate exists.
+ *
+ * Dangling imports (@foo.md where foo.md was deleted) are dropped to prevent ENOENT at
+ * session load.
+ */
+export function filterResolvableImports(
+  imports: string[],
+  rootDir: string
+): { kept: string[]; dropped: string[] } {
+  const kept: string[] = [];
+  const dropped: string[] = [];
+  const parentDir = dirname(rootDir);
+  for (const line of imports) {
+    const rel = line.slice(1);
+    const candidates = isAbsolute(rel)
+      ? [rel]
+      : [resolve(rootDir, rel), resolve(parentDir, rel)];
+    if (candidates.some(existsSync)) kept.push(line);
+    else dropped.push(line);
+  }
+  return { kept, dropped };
+}
+
+/**
+ * Write a timestamped backup of `oldContent` to a sibling of `oldPath` if it differs
+ * from `newContent`. Caller is responsible for having already read `oldContent` — this
+ * avoids a redundant readFileSync on the hot SessionStart rebuild path.
+ *
+ * Millisecond-precision timestamp prevents collisions when multiple SessionStart hooks
+ * fire within the same second.
+ */
+export function backupIfDiffers(
+  oldPath: string,
+  oldContent: string,
+  newContent: string
+): {
+  backupPath: string | null;
+  diff: { added: number; removed: number } | null;
+} {
+  if (oldContent === newContent) return { backupPath: null, diff: null };
+
+  const oldLines = oldContent.split("\n");
+  const newLines = newContent.split("\n");
+  const oldSet = new Set(oldLines);
+  const newSet = new Set(newLines);
+  let added = 0;
+  let removed = 0;
+  for (const l of newLines) if (!oldSet.has(l)) added++;
+  for (const l of oldLines) if (!newSet.has(l)) removed++;
+
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const backupPath = `${oldPath}.bak.${stamp}`;
+  writeFileSync(backupPath, oldContent);
+
+  return { backupPath, diff: { added, removed } };
+}
+
+/**
+ * Top-level preservation wrapper called from BuildCLAUDE.build().
+ *
+ * Reads the existing CLAUDE.md at most once, extracts user imports (if any), drops
+ * dangling ones, re-injects the rest into the new template-rendered content, and takes
+ * a safety backup if the final content differs from the existing file.
+ *
+ * Returns:
+ *   - `finalContent` — the content the caller should write
+ *   - `unchanged` — true when the existing file is byte-identical to `finalContent`, so
+ *     the caller can skip the writeFileSync without re-reading the file
+ *   - `log` — lines to surface to stderr (caller decides where to print)
+ */
+export function applyPreservation(args: {
+  existingPath: string;
+  newContent: string;
+  rootDir: string;
+}): { finalContent: string; unchanged: boolean; log: string[] } {
+  const { existingPath, newContent, rootDir } = args;
+  const log: string[] = [];
+
+  if (!existsSync(existingPath)) {
+    return { finalContent: newContent, unchanged: false, log };
+  }
+
+  const existing = readFileSync(existingPath, "utf-8");
+  const foundImports = extractUserImports(existing);
+
+  let merged = newContent;
+  if (foundImports.length > 0) {
+    const { kept, dropped } = filterResolvableImports(foundImports, rootDir);
+    merged = injectImportsAbovePaiHeading(newContent, kept);
+    log.push(`${LOG_PREFIX} preserved ${kept.length}, dropped ${dropped.length}`);
+    for (const d of dropped) {
+      log.push(`${LOG_PREFIX}   dropped broken import: ${d}`);
+    }
+  }
+
+  const unchanged = existing === merged;
+  if (!unchanged) {
+    const { backupPath, diff } = backupIfDiffers(existingPath, existing, merged);
+    if (backupPath && diff) {
+      log.push(`${LOG_PREFIX} backup: ${backupPath}`);
+      log.push(`${LOG_PREFIX} drift: +${diff.added} -${diff.removed} lines`);
+    }
+  }
+
+  return { finalContent: merged, unchanged, log };
+}


### PR DESCRIPTION
## Summary

Bundles fixes for #126 (preserve `@-imports` on install/upgrade) and #127 (minimal subset: pre-overwrite safety backup + drift log). Single new helper `preserve-claudemd.ts` plus a small wiring change inside `BuildCLAUDE.build()`.

- **#126 — full fidelity:** user `@-import` lines at the top of `~/.claude/CLAUDE.md` are extracted before overwrite, dangling targets dropped, resolvable ones re-injected above the `# PAI` heading in original order.
- **#127 — minimal scope (confirmed with @virtualian):** timestamped (ISO-ms) backup of the old file when content differs, plus a `+N -M lines` drift summary logged to stderr. The full interactive merge / `--force-template` / `--keep-current` / `--merge-auto` design from #127 is **deferred to a follow-up issue** — the issue author explicitly flagged it as needing a plan doc first.

## ⚠️ Note: issue #126's file guess was wrong

#126 says *"Files touched: `Releases/v4.0.3+/.claude/PAI-Install/engine/actions.ts` — wherever CLAUDE.md gets written during install/upgrade"*.

That file never writes `CLAUDE.md`. A grep of `engine/` for `CLAUDE.md` returns zero matches — `actions.ts` only does `git clone` (line 545). The real write path is `Releases/v4.0.3+/.claude/PAI/Tools/BuildCLAUDE.ts`, which renders `CLAUDE.md.template` → `CLAUDE.md` and runs in **three** situations:

1. First install (after `git clone`)
2. Upgrade (when the cloned repo updates)
3. **Every SessionStart hook** when `needsRebuild()` returns true — i.e., on every algorithm-version bump, DA-name change, or unresolved template variable

That third path is the one that keeps silently wiping `@-imports` between reinstalls. Fixing preservation inside `BuildCLAUDE.build()` covers all three.

## What's in the helper

`preserve-claudemd.ts` (163 lines) exposes:

- `extractUserImports(content)` — pure; pulls `@\S+` lines from the top of the file, stops at the first `#` heading
- `injectImportsAbovePaiHeading(template, imports)` — pure; splices imports above the first `# PAI` heading with a blank-line separator
- `filterResolvableImports(imports, rootDir)` — drops dangling targets. Tries **both** `rootDir`-relative AND parent-of-`rootDir`-relative resolution so Claude Code's actual HOME-relative `@.claude/foo.md` semantics work (the file at `~/.claude/foo.md` when the import is in `~/.claude/CLAUDE.md`)
- `backupIfDiffers(oldPath, oldContent, newContent)` — timestamped (ISO-ms) backup + line-delta counts
- `applyPreservation({ existingPath, newContent, rootDir })` — thin façade; returns `{ finalContent, unchanged, log }`

## Performance

`BuildCLAUDE.build()` runs on every SessionStart hook rebuild — this is a hot path. The implementation reads the existing `CLAUDE.md` **at most once per rebuild**, threads the buffer through `backupIfDiffers` instead of re-reading, and returns an `unchanged` flag so the caller can skip its own equality check. When the existing file has no `@-imports` (the common case), the helper short-circuits past `filterResolvableImports` and `injectImportsAbovePaiHeading`. The helper is silent on zero-change rebuilds to avoid stderr noise.

These optimizations came from a parallel 3-agent `/simplify` review during VERIFY — the original draft had three redundant `readFileSync` calls on the hot path.

## End-to-end verification against @virtualian's live `~/.claude/CLAUDE.md`

```
Extracted: [ @.claude/CLAUDE-USER.md, @.claude/marr/MARR-USER-CLAUDE.md ]
Kept:      [ @.claude/CLAUDE-USER.md, @.claude/marr/MARR-USER-CLAUDE.md ]
Dropped:   []
```

Merged output preserves both imports above the `# PAI` heading with correct ordering.

## Test plan

- [x] `bun test ./Releases/v4.0.3+/.claude/PAI/Tools/preserve-claudemd.test.ts` — 22 pass, 0 fail, 43 expects
- [x] `bun test ./Releases/v4.0.3+/.claude/PAI-Install/engine/skill-migration.test.ts` — 17 pass (no regression)
- [x] End-to-end dry run against real `~/.claude/CLAUDE.md` — both imports preserved, drift logged, backup path valid
- [ ] Reviewer: sanity-check the `filterResolvableImports` dual-candidate path logic against any other fork layouts you know of
- [ ] Reviewer: confirm the stderr log volume is acceptable — it's silent on no-op rebuilds and only logs when actually preserving/dropping/backing up
- [ ] Follow-up issue to track: full interactive-merge design from #127 (the parts not shipped here)

## Files changed

```
M  Releases/v4.0.3+/.claude/PAI/Tools/BuildCLAUDE.ts            (+12 -7)
A  Releases/v4.0.3+/.claude/PAI/Tools/preserve-claudemd.ts      (163)
A  Releases/v4.0.3+/.claude/PAI/Tools/preserve-claudemd.test.ts (248, 22 tests)
```

Zero changes to `engine/actions.ts`, `CLAUDE.md.template`, `needsRebuild()`, or any file outside `Tools/`.

Closes #126. Partially addresses #127 (minimal scope; full interactive merge to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)