### PR TITLE
Bundle two-root cleanup: PAI docs sweep + pack sources + commands architecture (#108, #113, #114)

### DIFF
--- a/Packs/ContextSearch/INSTALL.md
+++ b/Packs/ContextSearch/INSTALL.md
@@ -2,6 +2,8 @@
 
 **This guide is designed for AI agents installing this pack into a user's infrastructure.**
 
+> **Architecture note (#113):** This wizard is transitional. Under the post-#113 two-root model, slash commands canonically live at `~/.pai/commands/` and are symlinked into `~/.claude/commands/` by the main PAI installer's `migratePerPackCommands` action. The bash scripts below still copy directly to `~/.claude/commands/` for standalone installs, but the next main-installer run will detect the drift and convert real files to symlinks automatically. New pack wizards should delegate command placement to the main installer rather than copying directly.
+
 ---
 
 ## AI Agent Instructions

--- a/Packs/Research/src/MigrationNotes.md
+++ b/Packs/Research/src/MigrationNotes.md
@@ -11,28 +11,28 @@ Successfully migrated 4 research commands to the research skill's workflows dire
 ## Files Migrated
 
 ### 1. Claude WebSearch Research
-- **Source:** `~/.claude/commands/perform-claude-research.md`
+- **Source:** `~/.pai/commands/perform-claude-research.md`
 - **Destination:** `~/.pai/skills/Research/Workflows/ClaudeResearch.md`
 - **Size:** 3.6K
 - **Description:** Intelligent query decomposition with Claude's WebSearch tool (free, no API keys)
 - **Triggers:** "claude research", "use websearch", "claude only"
 
 ### 2. Perplexity API Research
-- **Source:** `~/.claude/commands/perform-perplexity-research.md`
+- **Source:** `~/.pai/commands/perform-perplexity-research.md`
 - **Destination:** `~/.pai/skills/Research/Workflows/PerplexityResearch.md`
 - **Size:** 8.1K
 - **Description:** Fast web search with query decomposition via Perplexity API
 - **Triggers:** "perplexity research", "use perplexity", "sonar"
 
 ### 3. Interview Preparation
-- **Source:** `~/.claude/commands/perform-interview-research.md`
+- **Source:** `~/.pai/commands/perform-interview-research.md`
 - **Destination:** `~/.pai/skills/Research/Workflows/InterviewResearch.md`
 - **Size:** 4.4K
 - **Description:** Tyler Cowen-style interview prep with Shannon surprise principle
 - **Triggers:** "interview research", "prepare interview questions", "sponsored interview"
 
 ### 4. AI Trends Analysis
-- **Source:** `~/.claude/commands/analyze-ai-trends.md`
+- **Source:** `~/.pai/commands/analyze-ai-trends.md`
 - **Destination:** `~/.pai/skills/Research/Workflows/AnalyzeAiTrends.md`
 - **Size:** 3.0K
 - **Description:** Deep trend analysis across historical AI news logs
@@ -83,7 +83,7 @@ Each workflow has:
 
 ✅ **ALL ORIGINALS PRESERVED**
 
-The original command files remain in `~/.claude/commands/`:
+The original command files remain in `~/.pai/commands/`:
 - `perform-claude-research.md` ✓
 - `perform-perplexity-research.md` ✓
 - `perform-interview-research.md` ✓

--- a/Packs/Telos/src/Workflows/Update.md
+++ b/Packs/Telos/src/Workflows/Update.md
@@ -78,7 +78,7 @@ This is the main command you'll use. It takes three parameters:
 - Content to add (the actual text)
 - Description of the change (for the changelog)
 
-!`FILE="$1"; CONTENT="$2"; DESCRIPTION="$3"; bun ~/.claude/commands/update-telos.ts "$FILE" "$CONTENT" "$DESCRIPTION"`
+!`FILE="$1"; CONTENT="$2"; DESCRIPTION="$3"; bun ~/.pai/commands/update-telos.ts "$FILE" "$CONTENT" "$DESCRIPTION"`
 
 ## List Valid TELOS Files
 !`echo "Valid TELOS files:
@@ -140,7 +140,7 @@ Use the update-telos command with:
 
 Example:
 ```bash
-bun ~/.claude/commands/update-telos.ts "BOOKS.md" "- *Project Hail Mary* by Andy Weir" "Added favorite book: Project Hail Mary"
+bun ~/.pai/commands/update-telos.ts "BOOKS.md" "- *Project Hail Mary* by Andy Weir" "Added favorite book: Project Hail Mary"
 ```
 
 ## Step 4: Confirm and Engage
@@ -286,7 +286,7 @@ The TypeScript implementation handles:
 - Content appending (preserves existing content)
 - Pacific Time timezone for consistency
 
-The script is at: `~/.claude/commands/update-telos.ts`
+The script is at: `~/.pai/commands/update-telos.ts`
 
 All backups are stored in: `~/.pai/PAI/USER/TELOS/Backups/`
 

--- a/Packs/Utilities/src/PAIUpgrade/SKILL.md
+++ b/Packs/Utilities/src/PAIUpgrade/SKILL.md
@@ -344,7 +344,7 @@ Extract: What user has been working on, patterns, open tasks
 ### Agent 3: PAI System State
 Analyze:
 - ~/.pai/skills/ (installed skills)
-- ~/.claude/hooks/ (active hooks)
+- ~/.pai/hooks/ (active hooks)
 - ~/.claude/settings.json (configuration)
 
 Extract: Current capabilities, potential gaps, system health

--- a/Packs/Utilities/src/PAIUpgrade/Workflows/Upgrade.md
+++ b/Packs/Utilities/src/PAIUpgrade/Workflows/Upgrade.md
@@ -71,7 +71,7 @@ Format as structured JSON."
 Agent 3 - PAI System State:
 "Analyze the current state of the user's PAI system:
 - List skills in ~/.pai/skills/
-- List hooks in ~/.claude/hooks/
+- List hooks in ~/.pai/hooks/
 - Read ~/.claude/settings.json
 
 Extract and return:

--- a/Releases/v4.0.3+/.claude/PAI-Install/engine/actions.ts
+++ b/Releases/v4.0.3+/.claude/PAI-Install/engine/actions.ts
@@ -14,6 +14,7 @@ import { detectSystem, validateElevenLabsKey } from "./detect";
 import { generateSettingsJson } from "./config-gen";
 import { resolveRepoUrl, readOriginRemote } from "./repo-url";
 import { migratePerPackSymlinks } from "./skill-migration";
+import { migratePerPackCommands } from "./command-migration";
 
 /**
  * Remove duplicate bun PATH entries from shell config.
@@ -595,6 +596,13 @@ export async function runRepository(
   // on fresh, closes the drift window before it opens; on upgrade, converts
   // pre-existing real directories to symlinks idempotently.
   await migratePerPackSymlinks(paiDir, emit);
+
+  // Canonicalize slash commands: ~/.claude/commands/<name>.md → symlinks
+  // pointing at ~/.pai/commands/<name>.md (GitHub #113). Same pattern as
+  // migratePerPackSymlinks above but scaled for flat files. Pack installers
+  // stage canonical sources into ~/.pai/commands/; this migrator wires up
+  // the harness scan path.
+  await migratePerPackCommands(paiDir, emit);
 
   await emit({ event: "progress", step: "repository", percent: 100, detail: "Repository ready" });
   await emit({ event: "step_complete", step: "repository" });

--- a/Releases/v4.0.3+/.claude/PAI-Install/engine/command-migration.ts
+++ b/Releases/v4.0.3+/.claude/PAI-Install/engine/command-migration.ts
@@ -1,0 +1,316 @@
+/**
+ * PAI Installer v4.0 — Per-Command Symlinks (GitHub #113)
+ *
+ * Converts each PAI-owned file under `~/.claude/commands/<name>.md` into a
+ * symlink pointing at `~/.pai/commands/<name>.md`. Claude Code's slash-command
+ * scanner is hardcoded to `~/.claude/commands/`, so the read path stays there
+ * while `~/.pai/commands/` becomes the single source of truth.
+ *
+ * This is the commands-side peer of `skill-migration.ts` (#110). Before this
+ * module shipped, slash commands had no canonical home under `~/.pai/` at all
+ * — each pack's INSTALL.md wizard copied files directly into `~/.claude/
+ * commands/`, producing silent drift when pack sources updated.
+ *
+ * Third-party commands (installed manually, not from a PAI pack) are preserved
+ * untouched: if a name does not exist in `~/.pai/commands/`, it is treated as
+ * third-party and skipped.
+ *
+ * Ownership rule:
+ *   - If `~/.pai/commands/<name>.md` exists as a real file → PAI-owned
+ *   - If `~/.pai/commands/` is empty (fresh install, right after git clone)
+ *     → the caller has not yet placed pack-source commands, so nothing to do.
+ *     Packs stage their sources into `~/.pai/commands/` during their own
+ *     install step; this migrator only converts the `~/.claude/commands/`
+ *     side into symlinks.
+ *
+ * Scope: flat .md files at the top level of `~/.claude/commands/`. Nested
+ * directories under commands/ are ignored — they are not how Claude Code
+ * loads slash commands.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readlinkSync,
+  lstatSync,
+  symlinkSync,
+  renameSync,
+  rmSync,
+  cpSync,
+} from "fs";
+import { homedir } from "os";
+import { join, resolve, relative, basename } from "path";
+import type { EngineEventHandler } from "./types";
+
+export type CommandClassification =
+  | "already-correct-symlink"
+  | "external-symlink"
+  | "third-party"
+  | "pai-only-claude-side"
+  | "pai-only-pai-side"
+  | "drift-both-sides";
+
+export interface CommandMigrationSummary {
+  migrated: number;
+  skipped: number;
+  backedUp: number;
+  failed: number;
+}
+
+const IGNORED_ENTRIES = new Set([".DS_Store", ".gitkeep"]);
+const BACKUP_SUFFIX_RE = /\.backup-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z$/;
+
+function isIgnored(name: string): boolean {
+  if (IGNORED_ENTRIES.has(name)) return true;
+  if (name.startsWith("._")) return true;
+  if (BACKUP_SUFFIX_RE.test(name)) return true;
+  return false;
+}
+
+/**
+ * Resolve the canonical PAI commands directory. Uses PAI_DIR env var if set
+ * (test-mode override or custom install layout), otherwise defaults to
+ * `~/.pai/commands`.
+ */
+function getPaiCommandsDir(): string {
+  let envPaiDir = (process.env.PAI_DIR || "").trim();
+  if (envPaiDir === "~" || envPaiDir.startsWith("~/")) {
+    envPaiDir = join(homedir(), envPaiDir.slice(1));
+  } else if (envPaiDir.startsWith("$HOME")) {
+    envPaiDir = join(homedir(), envPaiDir.slice("$HOME".length));
+  }
+  const paiHome = envPaiDir || join(homedir(), ".pai");
+  return join(paiHome, "commands");
+}
+
+/**
+ * Enumerate top-level command filenames under `dir` that are real .md files
+ * (not symlinks, not ignored). Used to compute the PAI-owned set from the
+ * canonical pai tree.
+ */
+function collectOwnedFiles(dir: string): Set<string> {
+  const out = new Set<string>();
+  if (!existsSync(dir)) return out;
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    if (isIgnored(e.name)) continue;
+    if (!e.name.endsWith(".md")) continue;
+    if (e.isFile() && !e.isSymbolicLink()) {
+      out.add(e.name);
+    }
+  }
+  return out;
+}
+
+/**
+ * Classify a top-level command filename. Pure function — safe to unit-test.
+ */
+export function classifyCommandFile(
+  name: string,
+  claudeCommandsDir: string,
+  paiCommandsDir: string,
+  paiOwnedSet: Set<string>,
+): CommandClassification {
+  const claudeSide = join(claudeCommandsDir, name);
+  const paiSide = join(paiCommandsDir, name);
+
+  let claudeStat: ReturnType<typeof lstatSync> | null = null;
+  let paiStat: ReturnType<typeof lstatSync> | null = null;
+  try { claudeStat = lstatSync(claudeSide); } catch { /* absent */ }
+  try { paiStat = lstatSync(paiSide); } catch { /* absent */ }
+
+  if (claudeStat?.isSymbolicLink()) {
+    let target: string;
+    try { target = readlinkSync(claudeSide); }
+    catch { return "external-symlink"; }
+    const resolvedTarget = resolve(claudeCommandsDir, target);
+    const expected = resolve(paiSide);
+    return resolvedTarget === expected ? "already-correct-symlink" : "external-symlink";
+  }
+
+  const claudeIsFile = claudeStat !== null && claudeStat.isFile();
+  const paiIsFile = paiStat !== null && paiStat.isFile() && !paiStat.isSymbolicLink();
+
+  if (!paiOwnedSet.has(name)) {
+    return "third-party";
+  }
+
+  if (claudeIsFile && paiIsFile) return "drift-both-sides";
+  if (claudeIsFile && !paiIsFile) return "pai-only-claude-side";
+  if (!claudeIsFile && paiIsFile) return "pai-only-pai-side";
+
+  return "third-party";
+}
+
+type MigrateMode = "move" | "link-only" | "drift";
+
+/**
+ * Migrate a single command file. Atomic per-file state machine with rollback.
+ *
+ * Modes:
+ *   "move"       — claude side has the file; move it to pai, symlink back
+ *   "link-only"  — pai side already has the file; just create the symlink
+ *   "drift"      — both sides have real files; back up pai, move claude over, symlink
+ */
+async function migrateCommand(
+  name: string,
+  claudeCommandsDir: string,
+  paiCommandsDir: string,
+  mode: MigrateMode,
+  summary: CommandMigrationSummary,
+  emit: EngineEventHandler,
+): Promise<void> {
+  const claudeSide = join(claudeCommandsDir, name);
+  const paiSide = join(paiCommandsDir, name);
+  const relativeTarget = relative(claudeCommandsDir, paiSide);
+
+  let backupPath: string | null = null;
+  if (mode === "drift") {
+    const ts = new Date().toISOString().replace(/[:.]/g, "-");
+    backupPath = join(paiCommandsDir, `${name}.backup-${ts}`);
+    renameSync(paiSide, backupPath);
+    summary.backedUp++;
+    await emit({
+      event: "message",
+      content: `Command "${name}": drift detected, backed up ~/.pai/commands/${name} → ${basename(backupPath)}`,
+    });
+  }
+
+  if (mode === "move" || mode === "drift") {
+    try {
+      renameSync(claudeSide, paiSide);
+    } catch (err: unknown) {
+      const code = (err as { code?: string } | null)?.code;
+      if (code === "EXDEV") {
+        cpSync(claudeSide, paiSide, { dereference: false });
+        rmSync(claudeSide, { force: true });
+      } else {
+        if (backupPath && !existsSync(paiSide)) {
+          try {
+            renameSync(backupPath, paiSide);
+            summary.backedUp--;
+          } catch { /* best effort */ }
+        }
+        throw err;
+      }
+    }
+  }
+
+  try {
+    symlinkSync(relativeTarget, claudeSide);
+  } catch (err) {
+    try {
+      if (mode === "move" || mode === "drift") {
+        renameSync(paiSide, claudeSide);
+      }
+      if (backupPath) {
+        renameSync(backupPath, paiSide);
+        summary.backedUp--;
+      }
+    } catch { /* best effort */ }
+    throw err;
+  }
+
+  summary.migrated++;
+  await emit({
+    event: "message",
+    content: `Command "${name}": migrated to ~/.pai/commands/${name} and symlinked.`,
+  });
+}
+
+/**
+ * Main entry point. Iterates the union of `<claudeDir>/commands` and
+ * `<paiCommandsDir>`, classifies each command, and migrates PAI-owned ones.
+ *
+ * @param paiDir The installer's `paiDir` variable — SEMANTICALLY the Claude
+ *               Code config root (`~/.claude`), despite the misleading name.
+ *               Same convention as skill-migration.ts.
+ * @param emit   Installer event handler.
+ * @returns      A summary counter of commands migrated/skipped/backed-up/failed.
+ *               Soft-fail: a single command's failure does NOT abort the run.
+ */
+export async function migratePerPackCommands(
+  paiDir: string,
+  emit: EngineEventHandler,
+): Promise<CommandMigrationSummary> {
+  const claudeCommandsDir = join(paiDir, "commands");
+  const paiCommandsDir = getPaiCommandsDir();
+  const summary: CommandMigrationSummary = { migrated: 0, skipped: 0, backedUp: 0, failed: 0 };
+
+  if (!existsSync(claudeCommandsDir) && !existsSync(paiCommandsDir)) {
+    return summary;
+  }
+
+  if (!existsSync(paiCommandsDir)) {
+    mkdirSync(paiCommandsDir, { recursive: true });
+    await emit({
+      event: "message",
+      content: `Created canonical commands directory at ${paiCommandsDir}.`,
+    });
+  }
+
+  if (!existsSync(claudeCommandsDir)) {
+    mkdirSync(claudeCommandsDir, { recursive: true });
+  }
+
+  const paiOwnedSet = collectOwnedFiles(paiCommandsDir);
+
+  const allNames = new Set<string>();
+  for (const e of readdirSync(claudeCommandsDir, { withFileTypes: true })) {
+    if (!isIgnored(e.name) && e.name.endsWith(".md")) allNames.add(e.name);
+  }
+  for (const e of readdirSync(paiCommandsDir, { withFileTypes: true })) {
+    if (!isIgnored(e.name) && e.name.endsWith(".md")) allNames.add(e.name);
+  }
+
+  if (allNames.size === 0) {
+    return summary;
+  }
+
+  for (const name of allNames) {
+    const kind = classifyCommandFile(name, claudeCommandsDir, paiCommandsDir, paiOwnedSet);
+    try {
+      switch (kind) {
+        case "already-correct-symlink":
+          summary.skipped++;
+          break;
+        case "external-symlink":
+        case "third-party":
+          summary.skipped++;
+          await emit({
+            event: "message",
+            content: `Command "${name}": third-party or external, preserved.`,
+          });
+          break;
+        case "pai-only-claude-side":
+          await migrateCommand(name, claudeCommandsDir, paiCommandsDir, "move", summary, emit);
+          break;
+        case "pai-only-pai-side":
+          await migrateCommand(name, claudeCommandsDir, paiCommandsDir, "link-only", summary, emit);
+          break;
+        case "drift-both-sides":
+          await migrateCommand(name, claudeCommandsDir, paiCommandsDir, "drift", summary, emit);
+          break;
+      }
+    } catch (err) {
+      summary.failed++;
+      const msg = err instanceof Error ? err.message : String(err);
+      await emit({
+        event: "message",
+        content: `Command "${name}": migration failed — ${msg}`,
+      });
+    }
+  }
+
+  await emit({
+    event: "message",
+    content:
+      `Command canonicalization: ${summary.migrated} migrated, ` +
+      `${summary.skipped} skipped, ${summary.backedUp} backed up, ` +
+      `${summary.failed} failed.`,
+  });
+
+  return summary;
+}
+
+export const __testInternals = { getPaiCommandsDir, collectOwnedFiles, migrateCommand };

--- a/Releases/v4.0.3+/.claude/PAI/README.md
+++ b/Releases/v4.0.3+/.claude/PAI/README.md
@@ -6,20 +6,26 @@ PAI is a general problem-solving system that magnifies human capabilities. It ru
 
 **CLAUDE.md** is the master config — generated from `CLAUDE.md.template` via `BuildCLAUDE.ts`. It defines execution modes, The Algorithm, and the context routing table. Claude Code loads it natively every session. A SessionStart hook keeps it fresh automatically.
 
-**This directory (`PAI/`)** contains all system documentation, tools, user context, and the SKILL.md that defines PAI as a skill. The rest of the system lives alongside it under `~/.claude/` (hooks, skills, settings, memory).
+**This directory (`PAI/`)** contains all system documentation, tools, user context, and the SKILL.md that defines PAI as a skill. Post-#101 two-root split, CODE (PAI internals, hooks, skills, agents, commands, memory) lives under `~/.pai/`, while Claude Code CONFIG (`settings.json`, `CLAUDE.md`) lives under `~/.claude/`.
 
 ## Directory Structure
 
 ```
-~/.claude/
+~/.claude/                     # Claude Code CONFIG root
   CLAUDE.md                    # Master config (generated from template)
   CLAUDE.md.template           # Source template with variables
   settings.json                # Single source of truth for all configuration
-  hooks/                       # Event lifecycle hooks (21+)
-  skills/                      # 12 categories, 49 skills — each with SKILL.md
-  MEMORY/                      # Persistent memory (work, learning, relationship, state)
+  skills/                      # Harness scan path — per-pack symlinks to ~/.pai/skills/
+  commands/                    # Harness scan path — symlinks to ~/.pai/commands/
+
+~/.pai/                        # PAI CODE root (canonical)
   PAI/                         # This directory — system docs + tools + user context
     Algorithm/                 # Versioned algorithm files + LATEST pointer
+  hooks/                       # Event lifecycle hooks (21+)
+  skills/                      # 12 categories, 49 skills — each with SKILL.md
+  agents/                      # Specialized agent definitions
+  commands/                    # Slash command source of truth
+  MEMORY/                      # Persistent memory (work, learning, relationship, state)
 ```
 
 ## Core Subsystems
@@ -31,7 +37,7 @@ The 7-phase execution engine: Observe, Think, Plan, Build, Execute, Verify, Lear
 12 hierarchical categories with 49 total skills in `~/.pai/skills/`, each with a `SKILL.md` defining triggers, workflows, and tools. Skills are the primary capability unit.
 
 ### Hooks (`THEHOOKSYSTEM.md`)
-21+ event hooks across the session lifecycle: SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop, SessionEnd. Defined in `settings.json`, implemented in `~/.claude/hooks/`.
+21+ event hooks across the session lifecycle: SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop, SessionEnd. Defined in `settings.json`, implemented in `~/.pai/hooks/`.
 
 ### Memory (`MEMORYSYSTEM.md`)
 Persistent storage across sessions:
@@ -84,6 +90,6 @@ All other documentation loads on-demand based on the routing table in CLAUDE.md.
 ## Extending PAI
 
 - **Add a skill:** Use the CreateSkill skill under Utilities
-- **Add a hook:** Create handler in `~/.claude/hooks/handlers/`, register in `settings.json`
+- **Add a hook:** Create handler in `~/.pai/hooks/handlers/`, register in `settings.json`
 - **Add startup files:** Append to `settings.json → loadAtStartup.files`
 - **Add user context:** Create files in `PAI/USER/`

--- a/Releases/v4.0.3+/.claude/PAI/THEHOOKSYSTEM.md
+++ b/Releases/v4.0.3+/.claude/PAI/THEHOOKSYSTEM.md
@@ -4,7 +4,7 @@
 
 **Event-Driven Automation Infrastructure**
 
-**Location:** `~/.claude/hooks/`
+**Location:** `~/.pai/hooks/`
 **Configuration:** `~/.claude/settings.json`
 **Status:** Active - 20 hooks running in production
 
@@ -657,7 +657,7 @@ async function main() {
 Decide which event should trigger your hook (SessionStart, Stop, PostToolUse, etc.)
 
 ### Step 2: Create Hook Script
-**Location:** `~/.claude/hooks/my-custom-hook.ts`
+**Location:** `~/.pai/hooks/my-custom-hook.ts`
 
 **Template:**
 ```typescript
@@ -698,7 +698,7 @@ main();
 
 ### Step 3: Make Executable
 ```bash
-chmod +x ~/.claude/hooks/my-custom-hook.ts
+chmod +x ~/.pai/hooks/my-custom-hook.ts
 ```
 
 ### Step 4: Add to settings.json
@@ -722,7 +722,7 @@ chmod +x ~/.claude/hooks/my-custom-hook.ts
 ### Step 5: Test
 ```bash
 # Test hook directly
-echo '{"session_id":"test","transcript_path":"/tmp/test.jsonl","hook_event_name":"Stop"}' | bun ~/.claude/hooks/my-custom-hook.ts
+echo '{"session_id":"test","transcript_path":"/tmp/test.jsonl","hook_event_name":"Stop"}' | bun ~/.pai/hooks/my-custom-hook.ts
 ```
 
 ### Step 6: Restart Claude Code
@@ -784,7 +784,7 @@ await Promise.race([readPromise, timeoutPromise]);
 ### Hook Not Running
 
 **Check:**
-1. Is hook script executable? `chmod +x ~/.claude/hooks/my-hook.ts`
+1. Is hook script executable? `chmod +x ~/.pai/hooks/my-hook.ts`
 2. Is path correct in settings.json? Use `${PAI_DIR}/hooks/...`
 3. Is settings.json valid JSON? `jq . ~/.claude/settings.json`
 4. Did you restart Claude Code after editing settings.json?
@@ -792,10 +792,10 @@ await Promise.race([readPromise, timeoutPromise]);
 **Debug:**
 ```bash
 # Test hook directly
-echo '{"session_id":"test","transcript_path":"/tmp/test.jsonl","hook_event_name":"Stop"}' | bun ~/.claude/hooks/my-hook.ts
+echo '{"session_id":"test","transcript_path":"/tmp/test.jsonl","hook_event_name":"Stop"}' | bun ~/.pai/hooks/my-hook.ts
 
 # Check hook logs (stderr output)
-tail -f ~/.claude/hooks/debug.log  # If you add logging
+tail -f ~/.pai/hooks/debug.log  # If you add logging
 ```
 
 ---
@@ -895,7 +895,7 @@ tail ~/.pai/MEMORY/RAW/$(date +%Y-%m)/$(date +%Y-%m-%d)_all-events.jsonl
 cat ~/.pai/MEMORY/STATE/agent-sessions.json | jq .
 
 # Check subagent-stop debug log
-tail -f ~/.claude/hooks/subagent-stop-debug.log
+tail -f ~/.pai/hooks/subagent-stop-debug.log
 ```
 
 **Fix:**
@@ -940,7 +940,7 @@ grep '"type":"user"' ~/.claude/projects/-Users-username--claude/*.jsonl | head -
 **Debug:**
 ```bash
 # Test context loading directly
-bun ~/.claude/hooks/LoadContext.hook.ts
+bun ~/.pai/hooks/LoadContext.hook.ts
 
 # Should output <system-reminder> with SKILL.md content
 ```
@@ -948,7 +948,7 @@ bun ~/.claude/hooks/LoadContext.hook.ts
 **Common Issues:**
 - Subagent sessions loading main context → Fixed (subagent detection in hook)
 - File not found → Check `PAI_DIR` environment variable
-- Permission denied → `chmod +x ~/.claude/hooks/LoadContext.hook.ts`
+- Permission denied → `chmod +x ~/.pai/hooks/LoadContext.hook.ts`
 
 ---
 
@@ -1122,13 +1122,13 @@ POST TOOL USE (2 hooks):
 
 KEY FILES:
 ~/.claude/settings.json              Hook configuration
-~/.claude/hooks/                     Hook scripts (22 files)
-~/.claude/hooks/handlers/            Handler modules (6 files)
-~/.claude/hooks/lib/                 Shared libraries (13 files)
-~/.claude/hooks/lib/learning-utils.ts Learning categorization
-~/.claude/hooks/lib/time.ts          PST timestamp utilities
-~/.claude/hooks/lib/event-types.ts   Typed event definitions (22 interfaces)
-~/.claude/hooks/lib/event-emitter.ts appendEvent() → events.jsonl
+~/.pai/hooks/                     Hook scripts (22 files)
+~/.pai/hooks/handlers/            Handler modules (6 files)
+~/.pai/hooks/lib/                 Shared libraries (13 files)
+~/.pai/hooks/lib/learning-utils.ts Learning categorization
+~/.pai/hooks/lib/time.ts          PST timestamp utilities
+~/.pai/hooks/lib/event-types.ts   Typed event definitions (22 interfaces)
+~/.pai/hooks/lib/event-emitter.ts appendEvent() → events.jsonl
 ~/.pai/MEMORY/WORK/               Work tracking
 ~/.pai/MEMORY/LEARNING/           Learning captures
 ~/.pai/MEMORY/STATE/              Runtime state

--- a/Releases/v4.0.3+/.claude/PAI/THENOTIFICATIONSYSTEM.md
+++ b/Releases/v4.0.3+/.claude/PAI/THENOTIFICATIONSYSTEM.md
@@ -268,7 +268,7 @@ Topic name acts as password - use random string for security.
 
 ### Implementation
 
-The notification service is in `~/.claude/hooks/lib/notifications.ts`:
+The notification service is in `~/.pai/hooks/lib/notifications.ts`:
 
 ```typescript
 import { notify, notifyTaskComplete, notifyBackgroundAgent, notifyError } from './lib/notifications';

--- a/Releases/v4.0.3+/.claude/PAI/Tools/FeatureRegistry.ts
+++ b/Releases/v4.0.3+/.claude/PAI/Tools/FeatureRegistry.ts
@@ -7,7 +7,7 @@
  * than Markdown because models are less likely to corrupt structured data.
  *
  * Usage:
- *   bun run ~/.claude/Tools/FeatureRegistry.ts <command> [options]
+ *   bun run ~/.pai/PAI/Tools/FeatureRegistry.ts <command> [options]
  *
  * Commands:
  *   init <project>              Initialize feature registry for project

--- a/Releases/v4.0.3+/.claude/skills/Research/MigrationNotes.md
+++ b/Releases/v4.0.3+/.claude/skills/Research/MigrationNotes.md
@@ -11,28 +11,28 @@ Successfully migrated 4 research commands to the research skill's workflows dire
 ## Files Migrated
 
 ### 1. Claude WebSearch Research
-- **Source:** `~/.claude/commands/perform-claude-research.md`
+- **Source:** `~/.pai/commands/perform-claude-research.md`
 - **Destination:** `~/.pai/skills/Research/Workflows/ClaudeResearch.md`
 - **Size:** 3.6K
 - **Description:** Intelligent query decomposition with Claude's WebSearch tool (free, no API keys)
 - **Triggers:** "claude research", "use websearch", "claude only"
 
 ### 2. Perplexity API Research
-- **Source:** `~/.claude/commands/perform-perplexity-research.md`
+- **Source:** `~/.pai/commands/perform-perplexity-research.md`
 - **Destination:** `~/.pai/skills/Research/Workflows/PerplexityResearch.md`
 - **Size:** 8.1K
 - **Description:** Fast web search with query decomposition via Perplexity API
 - **Triggers:** "perplexity research", "use perplexity", "sonar"
 
 ### 3. Interview Preparation
-- **Source:** `~/.claude/commands/perform-interview-research.md`
+- **Source:** `~/.pai/commands/perform-interview-research.md`
 - **Destination:** `~/.pai/skills/Research/Workflows/InterviewResearch.md`
 - **Size:** 4.4K
 - **Description:** Tyler Cowen-style interview prep with Shannon surprise principle
 - **Triggers:** "interview research", "prepare interview questions", "sponsored interview"
 
 ### 4. AI Trends Analysis
-- **Source:** `~/.claude/commands/analyze-ai-trends.md`
+- **Source:** `~/.pai/commands/analyze-ai-trends.md`
 - **Destination:** `~/.pai/skills/Research/Workflows/AnalyzeAiTrends.md`
 - **Size:** 3.0K
 - **Description:** Deep trend analysis across historical AI news logs
@@ -83,7 +83,7 @@ Each workflow has:
 
 ✅ **ALL ORIGINALS PRESERVED**
 
-The original command files remain in `~/.claude/commands/`:
+The original command files remain in `~/.pai/commands/`:
 - `perform-claude-research.md` ✓
 - `perform-perplexity-research.md` ✓
 - `perform-interview-research.md` ✓

--- a/Releases/v4.0.3+/.claude/skills/Utilities/PAIUpgrade/SKILL.md
+++ b/Releases/v4.0.3+/.claude/skills/Utilities/PAIUpgrade/SKILL.md
@@ -347,7 +347,7 @@ Extract: What user has been working on, patterns, open tasks
 ### Agent 3: PAI System State
 Analyze:
 - ~/.pai/skills/ (installed skills)
-- ~/.claude/hooks/ (active hooks)
+- ~/.pai/hooks/ (active hooks)
 - ~/.claude/settings.json (configuration)
 
 Extract: Current capabilities, potential gaps, system health

--- a/Releases/v4.0.3+/.claude/skills/Utilities/PAIUpgrade/Workflows/Upgrade.md
+++ b/Releases/v4.0.3+/.claude/skills/Utilities/PAIUpgrade/Workflows/Upgrade.md
@@ -72,7 +72,7 @@ Format as structured JSON."
 Agent 3 - PAI System State:
 "Analyze the current state of the user's PAI system:
 - List skills in ~/.pai/skills/
-- List hooks in ~/.claude/hooks/
+- List hooks in ~/.pai/hooks/
 - Read ~/.claude/settings.json
 
 Extract and return:


### PR DESCRIPTION
## Summary

Bundled fix for three peer issues from the post-#101 two-root split:

- **#108** — Remaining stale `~/.claude/{hooks,Tools}/` refs in `Releases/v4.0.3+/.claude/PAI/` docs/tool comments
- **#113** — Slash commands were forgotten by the two-root split; no canonical `~/.pai/commands/` home, no installer support
- **#114** — Stale CODE-root refs in pack sources + release skills mirror

Three separate commits, one per issue, for a clean revert story.

## User decisions received before execution

| Question | Answer |
|---|---|
| #113 commands architecture | **Option B** — canonical `~/.pai/commands/` + symlinks into `~/.claude/commands/` (peer of #110 skills fix) |
| `/cs` fate | **Slash command** — restore via `~/.pai/commands/cs.md` symlinked from `~/.claude/commands/cs.md` |
| Stale `~/.claude/PAI/` mirror deletion | **Leave alone** — out of scope, maintainer decides in a separate PR |

## What's in each commit

### 3f4e937 — Sweep stale `~/.claude/` refs in release-template `PAI/` tree (#108)

- `FeatureRegistry.ts:10`: usage comment `~/.claude/Tools/` → `~/.pai/PAI/Tools/`
- `THENOTIFICATIONSYSTEM.md`: `notifications.ts` path → `~/.pai/hooks/`
- `THEHOOKSYSTEM.md`: 16 hook-path refs swept via targeted replace_all
- `README.md`: prose + ASCII tree rewritten to document the post-#101 split (CONFIG at `~/.claude/`, CODE at `~/.pai/`)

**Note:** `RebuildPAI.ts:16`, `CLAUDE.md` algorithm anchor, and `Algorithm/v3.7.0.md` were already fixed in the repo on an earlier commit — the runtime files at `~/.pai/PAI/` are stale because they came from a pre-fix install, and will self-correct on the next install run.

### c60aedf — Sweep stale CODE-root refs in pack sources + release skills (#114)

- `Packs/Utilities/PAIUpgrade/SKILL.md` + `Workflows/Upgrade.md`: hooks path
- `Packs/Telos/Workflows/Update.md`: 3 `update-telos.ts` commands-path refs canonicalized to `~/.pai/commands/` (harness still reads via symlink)
- `Packs/Research/MigrationNotes.md`: 5 command refs canonicalized
- Mirrored fixes in `Releases/v4.0.3+/.claude/skills/**` copies

**Scope reality check:** The real repo-side surface was **16 refs across 5 files**, not the 446/138 #114 described. #114's count was against the runtime tree `~/.pai/skills/**`; most of those runtime refs come from pack sources that were already fixed in earlier commits, so they'll self-correct on reinstall.

### 50cb0b7 — Add canonical `~/.pai/commands/` home and installer migration (#113)

- **New:** `Releases/v4.0.3+/.claude/PAI-Install/engine/command-migration.ts` — `migratePerPackCommands()`, direct peer of `skill-migration.ts` scaled for flat `.md` files. Same state machine (move / link-only / drift modes), same rollback, same drift-backup pattern, same `getPaiCommandsDir()` env-var resolution. Bundled 6.81 KB, compiles clean.
- `actions.ts`: import + invocation right after `migratePerPackSymlinks` in `runRepository`. Runs on both fresh installs and upgrades.
- **New:** `Releases/v4.0.3+/.claude/commands/.gitkeep` — placeholder so the canonical dir ships with the release template.
- `Packs/ContextSearch/INSTALL.md`: architecture transition note at the top documenting the new model. Wizard bash scripts stay functional as-is — the next main-installer run detects drift from any direct copies and converts them into symlinks via the new migrator.

`cs.md` is already present in `Packs/ContextSearch/src/commands/` — the new migrator guarantees it reaches `~/.pai/commands/cs.md` with a symlink at `~/.claude/commands/cs.md` on the next install, restoring `/cs` as a first-class slash command.

## Explicitly NOT in this PR (follow-up work)

- **Full bash-script rewrite of `Packs/ContextSearch/INSTALL.md`** to delegate command placement to the main installer. Transition note added instead; wizards remain functional and self-correct on next main-installer run.
- **Deletion of stale `~/.claude/PAI/` mirror tree** — per user direction, out of scope (maintainer call for a separate PR).
- **Runtime-only stale refs** in `~/.pai/skills/**` (433 refs) and `~/.pai/PAI/**` (178 refs) — those self-correct on the next install run because the repo sources are already correct.
- **Removal of any `cs`-as-skill workaround** — I searched the repo and only the `context-search` skill exists by that name in the skill listing; no removable `cs` skill declaration was found.

## Verification

- `RebuildPAI.ts`: `bun build` → 3.97 KB, 0 errors
- `actions.ts`: `bun build` → 59.49 KB, 7 modules, 0 errors  
- `command-migration.ts`: `bun build` → 6.81 KB, 1 module, 0 errors
- Post-sweep CODE-root grep: **10 refs remain in Releases tree, all legitimate KEEP** (harness scan-path documentation in TypeScript comments: `GetCounts.ts`, `actions.ts`, `skill-migration.ts`, the new `command-migration.ts`)
- Post-sweep Packs grep: **6 refs remain in `Packs/ContextSearch/INSTALL.md`**, all in bash-wizard scripts that are functional under Option B (harness scan path `~/.claude/commands/` resolves via symlink to canonical `~/.pai/commands/`)
- KEEP list honored: spot-checked `~/.claude/settings.json` refs preserved in `THENOTIFICATIONSYSTEM.md:109, 207` and `PAIUpgrade/SKILL.md:351`

## Test plan

- [ ] Run the PAI installer on a fresh `~/.pai/` tree — verify `~/.pai/commands/` is created and populated from pack sources
- [ ] Run the installer on an existing tree with real files in `~/.claude/commands/` — verify they're moved to `~/.pai/commands/` and replaced with symlinks
- [ ] Verify `/cs` slash command is invocable after install
- [ ] Verify `/context-search` still works after install
- [ ] Regression-check: confirm skill-migration still runs correctly alongside command-migration
- [ ] `grep -rE '~/\.claude/(PAI\|MEMORY\|hooks\|agents\|commands\|Tools\|skills)/' Releases/ Packs/ --include='*.md' --include='*.ts'` returns only KEEP-list matches

Closes #108
Closes #113
Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)