### PR TITLE
Bundle installer engine cleanup: tryExec extraction + MEMORY migration (#121, #107)

### DIFF
--- a/Releases/v4.0.3+/.claude/PAI-Install/engine/actions.ts
+++ b/Releases/v4.0.3+/.claude/PAI-Install/engine/actions.ts
@@ -15,6 +15,7 @@ import { generateSettingsJson } from "./config-gen";
 import { resolveRepoUrl, readOriginRemote } from "./repo-url";
 import { migratePerPackSymlinks } from "./skill-migration";
 import { migratePerPackCommands } from "./command-migration";
+import { migrateMemoryDirectory } from "./memory-migration";
 import { tryExec } from "./exec";
 
 /**
@@ -582,6 +583,20 @@ export async function runRepository(
   // Migrate user context from v2.5/v3.0 location to v4.x canonical location
   if (state.installType === "upgrade") {
     await migrateUserContext(paiDir, emit);
+  }
+
+  // Relocate ~/.claude/MEMORY → ~/.pai/MEMORY for upgraders from v4.0.2
+  // (GitHub #107). Idempotent via marker file, refuses on ambiguity. Must
+  // run before any subsequent step that might write new MEMORY state at
+  // the canonical location. `paiDir` here is semantically the Claude Code
+  // config root — same naming convention as the skill/command migrators.
+  {
+    let canonicalPaiHome = (process.env.PAI_DIR || "").trim();
+    if (canonicalPaiHome === "~" || canonicalPaiHome.startsWith("~/")) {
+      canonicalPaiHome = join(homedir(), canonicalPaiHome.slice(1));
+    }
+    if (!canonicalPaiHome) canonicalPaiHome = join(homedir(), ".pai");
+    await migrateMemoryDirectory(paiDir, canonicalPaiHome, emit);
   }
 
   // Canonicalize each PAI-owned skill pack as a symlink from ~/.claude/skills

--- a/Releases/v4.0.3+/.claude/PAI-Install/engine/actions.ts
+++ b/Releases/v4.0.3+/.claude/PAI-Install/engine/actions.ts
@@ -15,6 +15,7 @@ import { generateSettingsJson } from "./config-gen";
 import { resolveRepoUrl, readOriginRemote } from "./repo-url";
 import { migratePerPackSymlinks } from "./skill-migration";
 import { migratePerPackCommands } from "./command-migration";
+import { tryExec } from "./exec";
 
 /**
  * Remove duplicate bun PATH entries from shell config.
@@ -145,14 +146,6 @@ function findExistingVoiceConfig(): { voiceId: string; aiName: string; source: s
     }
   }
   return null;
-}
-
-function tryExec(cmd: string, timeout = 30000): string | null {
-  try {
-    return execSync(cmd, { timeout, stdio: ["pipe", "pipe", "pipe"] }).toString().trim();
-  } catch {
-    return null;
-  }
 }
 
 // ─── User Context Migration (v2.5/v3.0 → v4.x) ─────────────────

--- a/Releases/v4.0.3+/.claude/PAI-Install/engine/detect.ts
+++ b/Releases/v4.0.3+/.claude/PAI-Install/engine/detect.ts
@@ -4,21 +4,16 @@
  * All detection is read-only and non-destructive.
  */
 
-import { execSync } from "child_process";
 import { existsSync, readFileSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
 import type { DetectionResult } from "./types";
+import { tryExec } from "./exec";
 
-function tryExec(cmd: string): string | null {
-  try {
-    return execSync(cmd, { timeout: 5000, stdio: ["pipe", "pipe", "pipe"] })
-      .toString()
-      .trim();
-  } catch {
-    return null;
-  }
-}
+// Detection probes are short and should fail fast. Historical timeout is 5s;
+// every call site in this module passes it explicitly to preserve that bound
+// on top of `tryExec`'s 30s default (see engine/exec.ts, GitHub #121).
+const DETECT_TIMEOUT_MS = 5000;
 
 function detectOS(): DetectionResult["os"] {
   const platform = process.platform === "darwin" ? "darwin" : "linux";
@@ -28,13 +23,16 @@ function detectOS(): DetectionResult["os"] {
   let name = "";
 
   if (platform === "darwin") {
-    const swVers = tryExec("sw_vers -productVersion");
+    const swVers = tryExec("sw_vers -productVersion", DETECT_TIMEOUT_MS);
     version = swVers || "";
     name = `macOS ${version}`;
   } else {
-    const release = tryExec("cat /etc/os-release 2>/dev/null | grep PRETTY_NAME | cut -d= -f2 | tr -d '\"'");
+    const release = tryExec(
+      "cat /etc/os-release 2>/dev/null | grep PRETTY_NAME | cut -d= -f2 | tr -d '\"'",
+      DETECT_TIMEOUT_MS,
+    );
     name = release || "Linux";
-    version = tryExec("uname -r") || "";
+    version = tryExec("uname -r", DETECT_TIMEOUT_MS) || "";
   }
 
   return { platform, arch, version, name };
@@ -43,7 +41,7 @@ function detectOS(): DetectionResult["os"] {
 function detectShell(): DetectionResult["shell"] {
   const shellPath = process.env.SHELL || "/bin/sh";
   const shellName = shellPath.split("/").pop() || "sh";
-  const version = tryExec(`${shellPath} --version 2>&1 | head -1`) || "";
+  const version = tryExec(`${shellPath} --version 2>&1 | head -1`, DETECT_TIMEOUT_MS) || "";
 
   return { name: shellName, version, path: shellPath };
 }
@@ -52,10 +50,10 @@ function detectTool(
   name: string,
   versionCmd: string
 ): { installed: boolean; version?: string; path?: string } {
-  const path = tryExec(`which ${name}`);
+  const path = tryExec(`which ${name}`, DETECT_TIMEOUT_MS);
   if (!path) return { installed: false };
 
-  const versionOutput = tryExec(versionCmd);
+  const versionOutput = tryExec(versionCmd, DETECT_TIMEOUT_MS);
   // Extract version number from output
   const versionMatch = versionOutput?.match(/(\d+\.\d+[\.\d]*)/);
   const version = versionMatch?.[1] || versionOutput || undefined;
@@ -138,8 +136,8 @@ export function detectSystem(): DetectionResult {
       claude: detectTool("claude", "claude --version 2>&1"),
       node: detectTool("node", "node --version"),
       brew: {
-        installed: tryExec("which brew") !== null,
-        path: tryExec("which brew") || undefined,
+        installed: tryExec("which brew", DETECT_TIMEOUT_MS) !== null,
+        path: tryExec("which brew", DETECT_TIMEOUT_MS) || undefined,
       },
     },
     existing: detectExisting(home, paiDir, configDir),

--- a/Releases/v4.0.3+/.claude/PAI-Install/engine/exec.ts
+++ b/Releases/v4.0.3+/.claude/PAI-Install/engine/exec.ts
@@ -1,0 +1,29 @@
+/**
+ * PAI Installer v4.0 — Shared subprocess helper (GitHub #121)
+ *
+ * Safe synchronous subprocess wrapper with a configurable timeout that
+ * returns `null` on any failure instead of throwing. Previously hand-rolled
+ * three times across `actions.ts`, `detect.ts`, and once more inline inside
+ * `repo-url.ts#readOriginRemote`. Promoted here as a leaf utility with zero
+ * imports from the installer tree, so any consumer (current or future) can
+ * depend on it without risking a circular import through the heavier graphs
+ * of the original hosts.
+ *
+ * Default timeout is 30s to match the historical `actions.ts` default.
+ * Call sites that need a tighter bound — e.g. `detect.ts` short probes —
+ * pass the timeout explicitly.
+ */
+
+import { execSync } from "child_process";
+
+export function tryExec(cmd: string, timeout = 30000): string | null {
+  try {
+    return execSync(cmd, {
+      encoding: "utf-8",
+      timeout,
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}

--- a/Releases/v4.0.3+/.claude/PAI-Install/engine/memory-migration.test.ts
+++ b/Releases/v4.0.3+/.claude/PAI-Install/engine/memory-migration.test.ts
@@ -1,0 +1,190 @@
+/**
+ * PAI Installer v4.0 — MEMORY migration tests (GitHub #107)
+ *
+ * Run from Releases/v4.0.3+/.claude/PAI-Install/:
+ *   bun test engine/memory-migration.test.ts
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdirSync,
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  rmSync,
+  readdirSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import type { EngineEvent } from "./types";
+import { migrateMemoryDirectory } from "./memory-migration";
+
+// ─── Fixture helpers ─────────────────────────────────────────────
+
+interface Fixture {
+  root: string;
+  claudeConfigDir: string;
+  paiDir: string;
+  sourceMemory: string;
+  destMemory: string;
+  markerPath: string;
+  events: EngineEvent[];
+  emit: (e: EngineEvent) => Promise<void>;
+  cleanup: () => void;
+}
+
+function setupFixture(): Fixture {
+  const root = mkdtempSync(join(tmpdir(), "pai-mem-mig-"));
+  const claudeConfigDir = join(root, "claude");
+  const paiDir = join(root, "pai");
+  mkdirSync(claudeConfigDir, { recursive: true });
+  mkdirSync(paiDir, { recursive: true });
+
+  const events: EngineEvent[] = [];
+  const emit = async (e: EngineEvent): Promise<void> => {
+    events.push(e);
+  };
+
+  return {
+    root,
+    claudeConfigDir,
+    paiDir,
+    sourceMemory: join(claudeConfigDir, "MEMORY"),
+    destMemory: join(paiDir, "MEMORY"),
+    markerPath: join(paiDir, "MEMORY", "STATE", "migration.json"),
+    events,
+    emit,
+    cleanup: () => {
+      try {
+        rmSync(root, { recursive: true, force: true });
+      } catch {
+        /* best effort */
+      }
+    },
+  };
+}
+
+function seedSourceMemory(fx: Fixture): void {
+  mkdirSync(fx.sourceMemory, { recursive: true });
+  mkdirSync(join(fx.sourceMemory, "LEARNING", "REFLECTION"), { recursive: true });
+  writeFileSync(join(fx.sourceMemory, "ABOUTME.md"), "# About\n");
+  writeFileSync(join(fx.sourceMemory, "LEARNING", "REFLECTION", "note.md"), "note\n");
+}
+
+function seedDestMemory(fx: Fixture): void {
+  mkdirSync(fx.destMemory, { recursive: true });
+  writeFileSync(join(fx.destMemory, "existing.md"), "already here\n");
+}
+
+// ─── Tests ───────────────────────────────────────────────────────
+
+describe("migrateMemoryDirectory", () => {
+  let fx: Fixture;
+  beforeEach(() => {
+    fx = setupFixture();
+  });
+  afterEach(() => fx.cleanup());
+
+  test("fresh install: noop when source absent", async () => {
+    const result = await migrateMemoryDirectory(fx.claudeConfigDir, fx.paiDir, fx.emit);
+    expect(result.action).toBe("noop-nothing-to-migrate");
+    expect(existsSync(fx.markerPath)).toBe(false);
+  });
+
+  test("noop when source has only .DS_Store", async () => {
+    mkdirSync(fx.sourceMemory, { recursive: true });
+    writeFileSync(join(fx.sourceMemory, ".DS_Store"), "");
+    const result = await migrateMemoryDirectory(fx.claudeConfigDir, fx.paiDir, fx.emit);
+    expect(result.action).toBe("noop-nothing-to-migrate");
+    expect(existsSync(fx.markerPath)).toBe(false);
+  });
+
+  test("upgrade: migrates source to dest and writes marker", async () => {
+    seedSourceMemory(fx);
+    const result = await migrateMemoryDirectory(fx.claudeConfigDir, fx.paiDir, fx.emit);
+
+    expect(result.action).toBe("migrated");
+    expect(result.method).toBe("rename");
+    expect(existsSync(fx.sourceMemory)).toBe(false);
+    expect(existsSync(join(fx.destMemory, "ABOUTME.md"))).toBe(true);
+    expect(existsSync(join(fx.destMemory, "LEARNING", "REFLECTION", "note.md"))).toBe(true);
+    expect(existsSync(fx.markerPath)).toBe(true);
+
+    const marker = JSON.parse(readFileSync(fx.markerPath, "utf-8"));
+    expect(marker.from).toBe(fx.sourceMemory);
+    expect(marker.to).toBe(fx.destMemory);
+    expect(marker.method).toBe("rename");
+    expect(typeof marker.migratedAt).toBe("string");
+  });
+
+  test("second run is idempotent: noop-already-migrated", async () => {
+    seedSourceMemory(fx);
+    await migrateMemoryDirectory(fx.claudeConfigDir, fx.paiDir, fx.emit);
+
+    // Re-create an empty source — second run should still see the marker
+    // and noop regardless of what's on the old side.
+    mkdirSync(fx.sourceMemory, { recursive: true });
+    writeFileSync(join(fx.sourceMemory, "new-leftover.md"), "should be ignored\n");
+
+    const result = await migrateMemoryDirectory(fx.claudeConfigDir, fx.paiDir, fx.emit);
+    expect(result.action).toBe("noop-already-migrated");
+    // Source untouched on the idempotent path
+    expect(existsSync(join(fx.sourceMemory, "new-leftover.md"))).toBe(true);
+  });
+
+  test("ambiguity: refuses when both sides populated and no marker", async () => {
+    seedSourceMemory(fx);
+    seedDestMemory(fx);
+
+    const result = await migrateMemoryDirectory(fx.claudeConfigDir, fx.paiDir, fx.emit);
+    expect(result.action).toBe("refused-ambiguous");
+    expect(result.sourceStats?.fileCount).toBeGreaterThan(0);
+    expect(result.destStats?.fileCount).toBeGreaterThan(0);
+    expect(result.diagnostic).toContain("refused");
+    // Neither side mutated
+    expect(existsSync(join(fx.sourceMemory, "ABOUTME.md"))).toBe(true);
+    expect(existsSync(join(fx.destMemory, "existing.md"))).toBe(true);
+    expect(existsSync(fx.markerPath)).toBe(false);
+
+    // Telemetry written to LEARNING/SYSTEM/
+    const telemetryDir = join(fx.paiDir, "MEMORY", "LEARNING", "SYSTEM");
+    expect(existsSync(telemetryDir)).toBe(true);
+    const entries = readdirSync(telemetryDir).filter((n) => n.startsWith("memory-migration-"));
+    expect(entries.length).toBeGreaterThan(0);
+  });
+
+  test("dry-run: would-migrate leaves filesystem untouched", async () => {
+    seedSourceMemory(fx);
+    const result = await migrateMemoryDirectory(fx.claudeConfigDir, fx.paiDir, fx.emit, { dryRun: true });
+
+    expect(result.action).toBe("dry-run-would-migrate");
+    expect(result.sourceStats?.fileCount).toBeGreaterThan(0);
+    // Filesystem unchanged
+    expect(existsSync(join(fx.sourceMemory, "ABOUTME.md"))).toBe(true);
+    expect(existsSync(fx.destMemory)).toBe(false);
+    expect(existsSync(fx.markerPath)).toBe(false);
+  });
+
+  test("dry-run: would-refuse-ambiguous on populated conflict", async () => {
+    seedSourceMemory(fx);
+    seedDestMemory(fx);
+    const result = await migrateMemoryDirectory(fx.claudeConfigDir, fx.paiDir, fx.emit, { dryRun: true });
+
+    expect(result.action).toBe("dry-run-would-refuse-ambiguous");
+    // No telemetry written for dry-run
+    const telemetryDir = join(fx.paiDir, "MEMORY", "LEARNING", "SYSTEM");
+    expect(existsSync(telemetryDir)).toBe(false);
+  });
+
+  test("post-migration telemetry entry written to LEARNING/SYSTEM", async () => {
+    seedSourceMemory(fx);
+    await migrateMemoryDirectory(fx.claudeConfigDir, fx.paiDir, fx.emit);
+    const telemetryDir = join(fx.paiDir, "MEMORY", "LEARNING", "SYSTEM");
+    const entries = readdirSync(telemetryDir).filter((n) => n.startsWith("memory-migration-"));
+    expect(entries.length).toBeGreaterThan(0);
+    const body = JSON.parse(readFileSync(join(telemetryDir, entries[0]), "utf-8"));
+    expect(body.action).toBe("migrated");
+    expect(body.method).toBe("rename");
+  });
+});

--- a/Releases/v4.0.3+/.claude/PAI-Install/engine/memory-migration.ts
+++ b/Releases/v4.0.3+/.claude/PAI-Install/engine/memory-migration.ts
@@ -1,0 +1,344 @@
+/**
+ * PAI Installer v4.0 — MEMORY directory migration (GitHub #107)
+ *
+ * PR #106 completed the CLAUDE_CONFIG_DIR + PAI_DIR two-root split for
+ * v4.0.3+, which relocates `MEMORY/` from `~/.claude/MEMORY/` to
+ * `~/.pai/MEMORY/`. Anyone upgrading from v4.0.2 with an existing
+ * `~/.claude/MEMORY/` directory needs to move it before their first
+ * post-upgrade session or they will boot with no correction history, no
+ * synthesis digest, and new writes landing in the new location while old
+ * data stays orphaned under the old root.
+ *
+ * PR #106 shipped the upgrade recipe as documentation only. This module
+ * automates detection and relocation so upgraders cannot accidentally skip
+ * the step. Patterned off `command-migration.ts` (PR #135) — same marker
+ * file idiom, same renameSync-with-EXDEV-fallback strategy, same event
+ * emitter wiring.
+ *
+ * ──── Semantics ────────────────────────────────────────────────
+ *
+ * 1. If the marker file `STATE/migration.json` exists in the destination
+ *    MEMORY, the migration has already run: noop.
+ * 2. If the source `<claudeConfigDir>/MEMORY` does not exist or contains
+ *    only ignorable entries (`.DS_Store`, etc.), there is nothing to
+ *    migrate: noop.
+ * 3. If the destination `<paiDir>/MEMORY` is absent or ignorable-only, the
+ *    migration runs: rename the source into place (falling back to a
+ *    recursive copy + delete on EXDEV), write the marker, write a
+ *    telemetry entry to LEARNING/SYSTEM/.
+ * 4. If BOTH sides contain meaningful content and there is no marker, the
+ *    migration REFUSES with a diagnostic listing both paths and their
+ *    size/mtime. Merging is a data-integrity decision the user must make.
+ *
+ * ──── Dry run ──────────────────────────────────────────────────
+ *
+ * Passing `{ dryRun: true }` performs all classification logic but makes
+ * no filesystem writes. The return value still indicates what would have
+ * happened, via the `dry-run-would-*` action variants.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  statSync,
+  renameSync,
+  cpSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import { join } from "path";
+import type { EngineEventHandler } from "./types";
+
+// ─── Types ─────────────────────────────────────────────────────
+
+export type MemoryMigrationAction =
+  | "noop-already-migrated"
+  | "noop-nothing-to-migrate"
+  | "migrated"
+  | "dry-run-would-migrate"
+  | "dry-run-would-refuse-ambiguous"
+  | "dry-run-noop"
+  | "refused-ambiguous";
+
+export interface DirStats {
+  path: string;
+  fileCount: number;
+  totalBytes: number;
+  latestMtime: string | null;
+}
+
+export interface MemoryMigrationResult {
+  action: MemoryMigrationAction;
+  source: string;
+  dest: string;
+  markerPath: string;
+  method?: "rename" | "copy-fallback";
+  sourceStats?: DirStats;
+  destStats?: DirStats;
+  diagnostic?: string;
+}
+
+export interface MemoryMigrationOptions {
+  dryRun?: boolean;
+}
+
+// ─── Helpers ───────────────────────────────────────────────────
+
+const IGNORED_BASENAMES = new Set([".DS_Store", ".gitkeep"]);
+
+function isIgnoredName(name: string): boolean {
+  if (IGNORED_BASENAMES.has(name)) return true;
+  if (name.startsWith("._")) return true;
+  return false;
+}
+
+/**
+ * Walk `dir` recursively and summarise content. Returns `null` if the
+ * directory doesn't exist. An empty-but-present directory returns zero
+ * counts, which the caller treats as "nothing meaningful here".
+ */
+function summariseDir(dir: string): DirStats | null {
+  if (!existsSync(dir)) return null;
+
+  let fileCount = 0;
+  let totalBytes = 0;
+  let latestMtimeMs = 0;
+
+  const walk = (cur: string): void => {
+    let entries;
+    try {
+      entries = readdirSync(cur, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      if (isIgnoredName(e.name)) continue;
+      const full = join(cur, e.name);
+      if (e.isDirectory()) {
+        walk(full);
+        continue;
+      }
+      if (e.isFile() || e.isSymbolicLink()) {
+        try {
+          const st = statSync(full);
+          fileCount += 1;
+          totalBytes += st.size;
+          if (st.mtimeMs > latestMtimeMs) latestMtimeMs = st.mtimeMs;
+        } catch {
+          // unreadable — still count as a file for ambiguity purposes
+          fileCount += 1;
+        }
+      }
+    }
+  };
+
+  walk(dir);
+
+  return {
+    path: dir,
+    fileCount,
+    totalBytes,
+    latestMtime: latestMtimeMs > 0 ? new Date(latestMtimeMs).toISOString() : null,
+  };
+}
+
+function hasMeaningfulContent(stats: DirStats | null): boolean {
+  return stats !== null && stats.fileCount > 0;
+}
+
+function markerPathFor(destMemoryDir: string): string {
+  return join(destMemoryDir, "STATE", "migration.json");
+}
+
+function readMarker(markerPath: string): boolean {
+  return existsSync(markerPath);
+}
+
+function writeMarker(
+  markerPath: string,
+  source: string,
+  dest: string,
+  method: "rename" | "copy-fallback",
+): void {
+  mkdirSync(join(markerPath, ".."), { recursive: true });
+  const payload = {
+    from: source,
+    to: dest,
+    migratedAt: new Date().toISOString(),
+    method,
+    schema: 1,
+  };
+  writeFileSync(markerPath, JSON.stringify(payload, null, 2) + "\n");
+}
+
+function writeTelemetry(
+  paiDir: string,
+  result: Omit<MemoryMigrationResult, "markerPath">,
+): void {
+  try {
+    const dir = join(paiDir, "MEMORY", "LEARNING", "SYSTEM");
+    mkdirSync(dir, { recursive: true });
+    const ts = new Date().toISOString().replace(/[:.]/g, "-");
+    const file = join(dir, `memory-migration-${ts}.json`);
+    writeFileSync(file, JSON.stringify({ ...result, recordedAt: new Date().toISOString() }, null, 2) + "\n");
+  } catch {
+    // telemetry is best-effort; never fail the install over a log write
+  }
+}
+
+function moveTree(source: string, dest: string): "rename" | "copy-fallback" {
+  mkdirSync(join(dest, ".."), { recursive: true });
+  try {
+    renameSync(source, dest);
+    return "rename";
+  } catch (err: unknown) {
+    const code = (err as { code?: string } | null)?.code;
+    if (code !== "EXDEV") throw err;
+    // Cross-filesystem: copy then delete. cpSync preserves mode by default.
+    cpSync(source, dest, { recursive: true, dereference: false, preserveTimestamps: true });
+    rmSync(source, { recursive: true, force: true });
+    return "copy-fallback";
+  }
+}
+
+// ─── Main entry point ─────────────────────────────────────────
+
+/**
+ * Migrate `<claudeConfigDir>/MEMORY` to `<paiDir>/MEMORY`.
+ *
+ * @param claudeConfigDir  e.g. `~/.claude` (the legacy location).
+ * @param paiDir           e.g. `~/.pai` (the canonical destination root).
+ * @param emit             Installer event handler.
+ * @param options.dryRun   If true, report what would happen without
+ *                         touching the filesystem.
+ */
+export async function migrateMemoryDirectory(
+  claudeConfigDir: string,
+  paiDir: string,
+  emit: EngineEventHandler,
+  options: MemoryMigrationOptions = {},
+): Promise<MemoryMigrationResult> {
+  const source = join(claudeConfigDir, "MEMORY");
+  const dest = join(paiDir, "MEMORY");
+  const markerPath = markerPathFor(dest);
+  const dryRun = options.dryRun === true;
+
+  // Idempotent: marker exists means the migration already ran.
+  if (readMarker(markerPath)) {
+    const result: MemoryMigrationResult = {
+      action: "noop-already-migrated",
+      source,
+      dest,
+      markerPath,
+    };
+    await emit({
+      event: "message",
+      content: `MEMORY migration: already complete (marker at ${markerPath}).`,
+    });
+    return result;
+  }
+
+  const sourceStats = summariseDir(source);
+  const destStats = summariseDir(dest);
+  const sourceHasContent = hasMeaningfulContent(sourceStats);
+  const destHasContent = hasMeaningfulContent(destStats);
+
+  // Ambiguity: both populated without a marker. Hard refuse — the user
+  // must resolve which copy is canonical.
+  if (sourceHasContent && destHasContent) {
+    const diagnostic =
+      `MEMORY migration refused: both locations contain data and no marker file exists.\n` +
+      `  source: ${sourceStats!.path} — ${sourceStats!.fileCount} files, ${sourceStats!.totalBytes} bytes, latest mtime ${sourceStats!.latestMtime}\n` +
+      `  dest:   ${destStats!.path} — ${destStats!.fileCount} files, ${destStats!.totalBytes} bytes, latest mtime ${destStats!.latestMtime}\n` +
+      `Resolve manually: inspect both, pick the canonical one, back up the other, ` +
+      `then re-run the installer. Auto-merge is not safe for memory state.`;
+
+    const result: MemoryMigrationResult = {
+      action: dryRun ? "dry-run-would-refuse-ambiguous" : "refused-ambiguous",
+      source,
+      dest,
+      markerPath,
+      sourceStats: sourceStats!,
+      destStats: destStats!,
+      diagnostic,
+    };
+    await emit({ event: "message", content: diagnostic });
+    if (!dryRun) {
+      writeTelemetry(paiDir, result);
+    }
+    return result;
+  }
+
+  // Nothing to migrate — source is absent or ignorable-only.
+  if (!sourceHasContent) {
+    const result: MemoryMigrationResult = {
+      action: dryRun ? "dry-run-noop" : "noop-nothing-to-migrate",
+      source,
+      dest,
+      markerPath,
+      sourceStats: sourceStats ?? undefined,
+      destStats: destStats ?? undefined,
+    };
+    await emit({
+      event: "message",
+      content: existsSync(source)
+        ? `MEMORY migration: nothing to migrate (source ${source} has no meaningful content).`
+        : `MEMORY migration: nothing to migrate (source ${source} does not exist).`,
+    });
+    return result;
+  }
+
+  // Migration eligible: source has content, dest is empty/absent.
+  if (dryRun) {
+    const result: MemoryMigrationResult = {
+      action: "dry-run-would-migrate",
+      source,
+      dest,
+      markerPath,
+      sourceStats: sourceStats!,
+      destStats: destStats ?? undefined,
+    };
+    await emit({
+      event: "message",
+      content:
+        `MEMORY migration (dry-run): would move ${source} → ${dest} ` +
+        `(${sourceStats!.fileCount} files, ${sourceStats!.totalBytes} bytes).`,
+    });
+    return result;
+  }
+
+  // Real migration. If dest exists but only as an ignorable-only stub,
+  // remove it so renameSync has a clean target.
+  if (existsSync(dest)) {
+    rmSync(dest, { recursive: true, force: true });
+  }
+
+  const method = moveTree(source, dest);
+  writeMarker(markerPath, source, dest, method);
+
+  const result: MemoryMigrationResult = {
+    action: "migrated",
+    source,
+    dest,
+    markerPath,
+    method,
+    sourceStats: sourceStats!,
+  };
+  await emit({
+    event: "message",
+    content:
+      `MEMORY migration complete: ${source} → ${dest} ` +
+      `(${sourceStats!.fileCount} files, method=${method}).`,
+  });
+  writeTelemetry(paiDir, result);
+  return result;
+}
+
+export const __testInternals = {
+  summariseDir,
+  hasMeaningfulContent,
+  markerPathFor,
+  moveTree,
+  writeMarker,
+};

--- a/Releases/v4.0.3+/.claude/PAI-Install/engine/repo-url.ts
+++ b/Releases/v4.0.3+/.claude/PAI-Install/engine/repo-url.ts
@@ -7,9 +7,9 @@
  *   3. DEFAULT_PAI_REPO_URL (upstream fallback)
  */
 
-import { execSync } from "child_process";
 import { existsSync } from "fs";
 import { join } from "path";
+import { tryExec } from "./exec";
 
 export const DEFAULT_PAI_REPO_URL = "https://github.com/danielmiessler/Personal_AI_Infrastructure.git";
 
@@ -46,14 +46,7 @@ export function resolveRepoUrl(paiDir?: string): ResolvedRepoUrl {
 export function readOriginRemote(paiDir: string): string | null {
   if (!existsSync(join(paiDir, ".git"))) return null;
 
-  try {
-    // 5s timeout guards against hangs on corrupted repos.
-    const raw = execSync(
-      `git -C "${paiDir}" remote get-url origin 2>/dev/null`,
-      { encoding: "utf-8", timeout: 5000 }
-    ).trim();
-    return raw || null;
-  } catch {
-    return null;
-  }
+  // 5s timeout guards against hangs on corrupted repos.
+  const raw = tryExec(`git -C "${paiDir}" remote get-url origin 2>/dev/null`, 5000);
+  return raw || null;
 }


### PR DESCRIPTION
Bundles two installer-engine issues on a single branch with one commit each for bisectability.

## #121 — Promote `tryExec` into shared `engine/exec.ts`

Extract the triplicated safe-subprocess helper into a leaf utility module with zero imports from the installer tree. Replaces three copies:

- `actions.ts` — delete local `tryExec`, import from `./exec`
- `detect.ts` — delete local `tryExec`, import from `./exec`, pass explicit `5000ms` timeout at every call site to preserve the historical detect-probe bound (`tryExec` default is `30000ms`, matching `actions.ts`)
- `repo-url.ts` — rewrite `readOriginRemote` around `tryExec`, preserving the `.git` `existsSync` short-circuit

Zero behavioral change — purely structural consolidation. Originally flagged by the /simplify review in PR #120 (#115 fix) as pre-existing debt and deferred out of that scope.

Commit: `cc0fcc5`

## #107 — Automate MEMORY migration for v4.0.2 → v4.0.3+ upgraders

Ships `engine/memory-migration.ts` patterned off `command-migration.ts` (PR #135). Automates the `~/.claude/MEMORY/` → `~/.pai/MEMORY/` relocation that PR #106 documented but left manual.

**Semantics**:
- **Idempotent** via marker file at `<dest>/STATE/migration.json`. Second run sees the marker and noops regardless of source state.
- **Refuses ambiguity**: if both source and dest contain meaningful content without a marker, emits a diagnostic listing both paths, file counts, and latest mtime, then stops. Merging is a data-integrity decision outside installer scope.
- **Atomic move**: `renameSync` first, `cpSync` + `rmSync` fallback on `EXDEV`. Preserves mode and timestamps. Marker written inside the new location after the move.
- **Meaningful-content filter**: ignores `.DS_Store` and dotfile cruft so empty stub directories don't trip ambiguity detection.
- **Dry-run mode** (`options.dryRun=true`) reports the intended action without touching the filesystem and without writing telemetry.
- **Telemetry** logged to `<paiDir>/MEMORY/LEARNING/SYSTEM/memory-migration-*.json` so the outcome surfaces in the learning digest, not stdout where users miss it.

**Wiring**: Called from `runRepository` immediately after `migrateUserContext` and before `migratePerPackSymlinks` / `migratePerPackCommands`. Runs on every install path; the idempotent + noop-on-absent-source semantics make this safe for fresh installs.

**Tests** (`engine/memory-migration.test.ts`, 8 cases — all passing):
- fresh install → `noop-nothing-to-migrate`
- source has only `.DS_Store` → noop
- upgrade → renames source into dest, writes marker, preserves nested files, `method: "rename"`
- second run → `noop-already-migrated` regardless of source state
- ambiguity → `refused-ambiguous`, neither side mutated, telemetry written
- dry-run would-migrate → filesystem untouched
- dry-run would-refuse-ambiguous → no telemetry written
- post-migration telemetry entry exists in `LEARNING/SYSTEM/`

Commit: `dad8df5`

## Verification

- [x] `engine/exec.ts` typechecks via `bun build --target=bun`
- [x] `engine/actions.ts`, `engine/detect.ts`, `engine/repo-url.ts` typecheck clean after refactor
- [x] `engine/memory-migration.ts` + `engine/memory-migration.test.ts` typecheck
- [x] `bun test engine/memory-migration.test.ts` — 8/8 pass
- [x] `bun test engine/skill-migration.test.ts` — 17/17 pass (regression check)
- [x] `bash -n Releases/v4.0.3+/.claude/install.sh`
- [x] `bash -n Releases/v4.0.3+/.claude/PAI-Install/install.sh`

## Test plan

- [ ] Maintainer review of #121 structural change (tryExec extraction)
- [ ] Maintainer review of #107 semantics (ambiguity refusal, marker format, telemetry path)
- [ ] Manual dry-run on a populated `~/.claude/MEMORY/` if desired: import `migrateMemoryDirectory`, call with `{ dryRun: true }`, verify no writes

## Issues closed
- Closes #121
- Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)