### PR TITLE
Bundle upstream cherries: statusline spacing + AlgorithmTab dead docs (#91 partial, #83 verified)

### DIFF
--- a/.claude/statusline-full.sh
+++ b/.claude/statusline-full.sh
@@ -1076,24 +1076,24 @@ printf "${SLATE_600}────────────────────
 
 case "$MODE" in
     nano)
-        printf "${LEARN_PRIMARY}◎${RESET} ${LEARN_WORK}📁${RESET}${SLATE_300}${work_count}${RESET} ${LEARN_SIGNALS}✦${RESET}${SLATE_300}${ratings_count}${RESET} ${LEARN_SESSIONS}⊕${RESET}${SLATE_300}${sessions_count}${RESET} ${LEARN_RESEARCH}◇${RESET}${SLATE_300}${research_count}${RESET}\n"
+        printf "${LEARN_PRIMARY}◎${RESET} ${LEARN_WORK}📁 ${RESET}${SLATE_300}${work_count}${RESET} ${LEARN_SIGNALS}✦ ${RESET}${SLATE_300}${ratings_count}${RESET} ${LEARN_SESSIONS}⊕ ${RESET}${SLATE_300}${sessions_count}${RESET} ${LEARN_RESEARCH}◇ ${RESET}${SLATE_300}${research_count}${RESET}\n"
         ;;
     micro)
-        printf "${LEARN_PRIMARY}◎${RESET} ${LEARN_WORK}📁${RESET}${SLATE_300}${work_count}${RESET} ${LEARN_SIGNALS}✦${RESET}${SLATE_300}${ratings_count}${RESET} ${LEARN_SESSIONS}⊕${RESET}${SLATE_300}${sessions_count}${RESET} ${LEARN_RESEARCH}◇${RESET}${SLATE_300}${research_count}${RESET}\n"
+        printf "${LEARN_PRIMARY}◎${RESET} ${LEARN_WORK}📁 ${RESET}${SLATE_300}${work_count}${RESET} ${LEARN_SIGNALS}✦ ${RESET}${SLATE_300}${ratings_count}${RESET} ${LEARN_SESSIONS}⊕ ${RESET}${SLATE_300}${sessions_count}${RESET} ${LEARN_RESEARCH}◇ ${RESET}${SLATE_300}${research_count}${RESET}\n"
         ;;
     mini)
         printf "${LEARN_PRIMARY}◎${RESET} ${LEARN_SECONDARY}MEMORY:${RESET} "
-        printf "${LEARN_WORK}📁${RESET}${SLATE_300}${work_count}${RESET} "
-        printf "${SLATE_600}│${RESET} ${LEARN_SIGNALS}✦${RESET}${SLATE_300}${ratings_count}${RESET} "
-        printf "${SLATE_600}│${RESET} ${LEARN_SESSIONS}⊕${RESET}${SLATE_300}${sessions_count}${RESET} "
-        printf "${SLATE_600}│${RESET} ${LEARN_RESEARCH}◇${RESET}${SLATE_300}${research_count}${RESET}\n"
+        printf "${LEARN_WORK}📁 ${RESET}${SLATE_300}${work_count}${RESET} "
+        printf "${SLATE_600}│${RESET} ${LEARN_SIGNALS}✦ ${RESET}${SLATE_300}${ratings_count}${RESET} "
+        printf "${SLATE_600}│${RESET} ${LEARN_SESSIONS}⊕ ${RESET}${SLATE_300}${sessions_count}${RESET} "
+        printf "${SLATE_600}│${RESET} ${LEARN_RESEARCH}◇ ${RESET}${SLATE_300}${research_count}${RESET}\n"
         ;;
     normal)
         printf "${LEARN_PRIMARY}◎${RESET} ${LEARN_SECONDARY}MEMORY:${RESET} "
-        printf "${LEARN_WORK}📁${RESET}${SLATE_300}${work_count}${RESET} ${LEARN_WORK}Work${RESET} "
-        printf "${SLATE_600}│${RESET} ${LEARN_SIGNALS}✦${RESET}${SLATE_300}${ratings_count}${RESET} ${LEARN_SIGNALS}Ratings${RESET} "
-        printf "${SLATE_600}│${RESET} ${LEARN_SESSIONS}⊕${RESET}${SLATE_300}${sessions_count}${RESET} ${LEARN_SESSIONS}Sessions${RESET} "
-        printf "${SLATE_600}│${RESET} ${LEARN_RESEARCH}◇${RESET}${SLATE_300}${research_count}${RESET} ${LEARN_RESEARCH}Research${RESET}\n"
+        printf "${LEARN_WORK}📁 ${RESET}${SLATE_300}${work_count}${RESET} ${LEARN_WORK}Work${RESET} "
+        printf "${SLATE_600}│${RESET} ${LEARN_SIGNALS}✦ ${RESET}${SLATE_300}${ratings_count}${RESET} ${LEARN_SIGNALS}Ratings${RESET} "
+        printf "${SLATE_600}│${RESET} ${LEARN_SESSIONS}⊕ ${RESET}${SLATE_300}${sessions_count}${RESET} ${LEARN_SESSIONS}Sessions${RESET} "
+        printf "${SLATE_600}│${RESET} ${LEARN_RESEARCH}◇ ${RESET}${SLATE_300}${research_count}${RESET} ${LEARN_RESEARCH}Research${RESET}\n"
         ;;
 esac
 printf "${SLATE_600}────────────────────────────────────────────────────────────────────────${RESET}\n"

--- a/Releases/v4.0.3+/.claude/PAI/THEHOOKSYSTEM.md
+++ b/Releases/v4.0.3+/.claude/PAI/THEHOOKSYSTEM.md
@@ -187,8 +187,7 @@ Claude Code supports the following hook events:
         { "type": "command", "command": "${PAI_DIR}/hooks/LastResponseCache.hook.ts" },
         { "type": "command", "command": "${PAI_DIR}/hooks/ResponseTabReset.hook.ts" },
         { "type": "command", "command": "${PAI_DIR}/hooks/VoiceCompletion.hook.ts" },
-        { "type": "command", "command": "${PAI_DIR}/hooks/DocIntegrity.hook.ts" },
-        { "type": "command", "command": "${PAI_DIR}/hooks/AlgorithmTab.hook.ts" }
+        { "type": "command", "command": "${PAI_DIR}/hooks/DocIntegrity.hook.ts" }
       ]
     }
   ]
@@ -211,9 +210,6 @@ Each Stop hook is a self-contained `.hook.ts` file that reads stdin via shared `
 - Calls `handlers/VoiceNotification.ts` for voice delivery
 - Voice gate: only main sessions (checks `kitty-sessions/{sessionId}.json`)
 - Subagents have no kitty-sessions file → voice blocked
-
-**`AlgorithmTab.hook.ts`** — Show Algorithm phase + progress in Kitty tab title
-- Reads `work.json`, finds most recently updated active session, sets tab title
 
 **`DocIntegrity.hook.ts`** — Cross-reference + semantic drift checks
 - Calls `handlers/DocCrossRefIntegrity.ts` — deterministic + inference-powered doc updates
@@ -1085,7 +1081,7 @@ HOOK LIFECYCLE:
 6. Hook exits 0 (always succeeds)
 7. Claude Code continues
 
-HOOKS BY EVENT (22 hooks total):
+HOOKS BY EVENT (21 hooks total):
 
 SESSION START (2 hooks):
   KittyEnvPersist.hook.ts        Persist Kitty env vars + tab reset
@@ -1103,12 +1099,11 @@ USER PROMPT SUBMIT (3 hooks):
   UpdateTabTitle.hook.ts         Tab title + working state (orange)
   SessionAutoName.hook.ts        Auto-name session from first prompt
 
-STOP (5 hooks):
+STOP (4 hooks):
   LastResponseCache.hook.ts      Cache response for RatingCapture bridge
   ResponseTabReset.hook.ts       Tab title/color reset after response
   VoiceCompletion.hook.ts        Voice TTS (main sessions only)
   DocIntegrity.hook.ts           Cross-ref + semantic drift checks
-  AlgorithmTab.hook.ts           Algorithm phase + progress in tab
 
 PRE TOOL USE (4 hooks):
   SecurityValidator.hook.ts      Security validation [Bash, Edit, Write, Read]

--- a/Releases/v4.0.3+/.claude/hooks/README.md
+++ b/Releases/v4.0.3+/.claude/hooks/README.md
@@ -61,8 +61,7 @@ Hooks are TypeScript scripts that execute at specific lifecycle events in Claude
 │  Stop ──┬──► LastResponseCache (cache response for ratings)         │
 │         ├──► ResponseTabReset (tab title/color reset)              │
 │         ├──► VoiceCompletion (TTS voice line)                      │
-│         ├──► DocIntegrity (cross-ref checks)                       │
-│         └──► AlgorithmTab (phase + progress in tab)                │
+│         └──► DocIntegrity (cross-ref checks)                       │
 │                                                                     │
 │  SessionEnd ──┬──► WorkCompletionLearning (insight extraction)      │
 │               ├──► SessionCleanup (work completion + state clear)   │
@@ -157,7 +156,6 @@ interface StopPayload extends BasePayload {
 | `LastResponseCache.hook.ts` | Cache last response for RatingCapture bridge | No | None |
 | `ResponseTabReset.hook.ts` | Reset Kitty tab title/color after response | No | Kitty terminal |
 | `VoiceCompletion.hook.ts` | Send 🗣️ voice line to TTS server | No | Voice Server |
-| `AlgorithmTab.hook.ts` | Show Algorithm phase + progress in tab | No | `work.json` |
 | `DocIntegrity.hook.ts` | Cross-ref + semantic drift checks | No | Inference API |
 
 ### SessionEnd Hooks
@@ -481,4 +479,4 @@ Use this checklist when adding or modifying hooks:
 ---
 
 *Last updated: 2026-02-25*
-*Hooks count: 22 | Events: 6 | Shared libs: 13*
+*Hooks count: 21 | Events: 6 | Shared libs: 13*


### PR DESCRIPTION
## Summary

Bundle cherry-pick pass from the 2026-03-18 upstream scan in #91. Scope was 5 sub-items; verification revealed **3 were already in-tree** in this fork and **2 required real fixes**. Partial close of #91 (the mechanical low-risk subset), no change to #112's VoiceServer removal surface.

## Commits

| # | Commit | Sub-issue | Upstream PR |
|---|--------|-----------|-------------|
| 1 | 620165e | #91 — Statusline MEMORY row spacing | danielmiessler/Personal_AI_Infrastructure#910, #900 |
| 2 | 6b36870 | #91 — Remove dead AlgorithmTab.hook.ts docs | danielmiessler/Personal_AI_Infrastructure#968 |

## What changed

### 620165e — Statusline MEMORY icon spacing (upstream #910/#900, #91)

`.claude/statusline-full.sh` rendered the MEMORY row as `📁478 ✦3000 ⊕12 ◇7` because the icon glyphs were immediately followed by `\${RESET}\${SLATE_300}\${count}` with no space. Added a single space after each icon (📁, ✦, ⊕, ◇) at 10 print sites across the nano/micro/mini/normal modes. Matches the already-fixed layout in `Releases/v4.0.3+/.claude/statusline-command.sh`. `bash -n` clean.

### 6b36870 — AlgorithmTab.hook.ts dead doc refs (upstream #968, #91)

`AlgorithmTab.hook.ts` has never existed in this tree but was documented in 5 places across 2 files, mirrored in release and runtime:

- `Releases/v4.0.3+/.claude/PAI/THEHOOKSYSTEM.md` — Stop-hooks JSON example, "What They Do" subsection, Quick Reference card, "HOOKS BY EVENT (22→21)" and "STOP (5→4)" counts
- `Releases/v4.0.3+/.claude/hooks/README.md` — ASCII lifecycle diagram, Stop Hooks registry table, footer hook count
- `~/.pai/PAI/THEHOOKSYSTEM.md` + `~/.pai/hooks/README.md` — runtime mirrors of the above

No code change, no behavior change — these are dead docs only. Adjacent VoiceCompletion.hook.ts entries are intentionally untouched: they belong to #112's removal PR.

The live `AlgorithmTabPhase` type in `hooks/lib/tab-constants.ts` / `tab-setter.ts` / `PRDSync.hook.ts` is a separate thing (a type alias for Algorithm phase tab states) and is deliberately NOT removed.

## #91 sub-items: verified already fixed in-tree

These three were flagged in the original scope but verification proved no code change was needed. They remain listed as "partial" on #91 because the bundle-tracker records them — I'm only documenting the verification here.

| Sub-item | Upstream | Status | Evidence |
|---|---|---|---|
| RatingCapture `safeSlice()` UTF-16 | #882 | **Already fixed** | PR #66 (commit 1cb8484) introduced `safeSlice()` at `RatingCapture.hook.ts:494-501`. All string truncations in the file already flow through it. Remaining `.slice()` calls operate on arrays or numeric-prefix substrings — none can split a surrogate pair. |
| `notifications.voice.enabled` gate | n/a (local #83) | **Already fixed** | PR #85 (commit 591473d) "fix: respect notifications.voice.enabled setting in voice server and hook (#83)". `isVoiceEnabled()` gate lives at `VoiceCompletion.hook.ts:36-48` with early-exit at lines 61-64. Verified live: settings.json has `notifications.voice.enabled: false`, gate returns `false`, hook exits silently. |
| CONTEXT_ROUTING.md dead refs | #883 | **Not applicable** | Upstream reorganized `USER/` to put projects under `TELOS/PROJECTS.md`. This fork kept `USER/PROJECTS/README.md` as its own directory. All 19 paths in `CONTEXT_ROUTING.md` resolve in both release and runtime trees. The `{PRINCIPAL.NAME}` template variable never appeared in this file (git log confirms). Following the upstream fix literally would have *created* a dead ref. |

## #91 remaining follow-ups (NOT in this PR)

- **#966** — Learning feedback loop regex (`loadLearningDigest()` uses `**Feedback:**` but files use `**Sentiment Summary:**`)
- **#842** — RatingCapture sentiment prompt contradiction (5/neutral false positives)
- **#951** — VoiceServer audio device probe + afplay timeout — **overlaps with #112, should be skipped if #112 lands first**
- **#891 / #890** — SKILL.md ISC system-of-record conflict with Algorithm PRD design

## #83 disposition

**Left OPEN on purpose.** The hook-handler side is already fixed (commit 591473d), and #112's removal plan explicitly schedules closing #83 as its own verification step when the entire voice stack is ripped out. Closing it now would steal that closure from #112. If #112 is abandoned, #83 can be closed directly with a pointer to 591473d.

## Test plan

- [x] `bash -n .claude/statusline-full.sh` — syntax clean
- [x] `grep -E '(📁|✦|⊕|◇)\$\{RESET\}\$\{SLATE_300\}' .claude/statusline-full.sh` returns zero hits (fix complete)
- [x] `grep AlgorithmTab Releases/v4.0.3+/.claude/PAI/THEHOOKSYSTEM.md Releases/v4.0.3+/.claude/hooks/README.md ~/.pai/PAI/THEHOOKSYSTEM.md ~/.pai/hooks/README.md` returns zero hits (doc cleanup complete in both release + runtime mirrors)
- [x] `grep AlgorithmTabPhase Releases/v4.0.3+/.claude/hooks/` still matches `tab-constants.ts` / `tab-setter.ts` / `PRDSync.hook.ts` — the live type is preserved, only the docs-for-a-nonexistent-file went away
- [x] Stop-hooks JSON example in THEHOOKSYSTEM.md still valid JSON (4 entries, correct trailing comma on DocIntegrity)
- [x] ASCII lifecycle diagram in hooks/README.md shows `└──► DocIntegrity` as new last entry
- [ ] Visual check in live terminal: statusline MEMORY row renders with visible space between icons and counts