### PR TITLE
Fix SecurityValidator yaml import crash via lazy dynamic load (#156)

### DIFF
--- a/Releases/v4.0.3+/.claude/hooks/SecurityValidator.hook.ts
+++ b/Releases/v4.0.3+/.claude/hooks/SecurityValidator.hook.ts
@@ -63,8 +63,21 @@
 import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
-import { parse as parseYaml } from 'yaml';
+import type { parse as YamlParse } from 'yaml';
 import { configPath, codePath } from './lib/paths';
+
+// Lazy yaml load — static `import 'yaml'` crashes module load when the package
+// isn't resolvable from this hook's directory.
+let parseYaml: typeof YamlParse | null = null;
+
+async function ensureYamlLoaded(): Promise<void> {
+  if (parseYaml) return;
+  try {
+    parseYaml = (await import('yaml')).parse;
+  } catch {
+    parseYaml = null;
+  }
+}
 
 // ========================================
 // Security Event Logging
@@ -214,6 +227,16 @@ function loadPatterns(): PatternsConfig {
     return {
       version: '0.0',
       philosophy: { mode: 'permissive', principle: 'No patterns loaded - fail open' },
+      bash: { trusted: [], blocked: [], confirm: [], alert: [] },
+      paths: { zeroAccess: [], readOnly: [], confirmWrite: [], noDelete: [] },
+      projects: {}
+    };
+  }
+
+  if (!parseYaml) {
+    return {
+      version: '0.0',
+      philosophy: { mode: 'permissive', principle: 'YAML parser unavailable - fail open' },
       bash: { trusted: [], blocked: [], confirm: [], alert: [] },
       paths: { zeroAccess: [], readOnly: [], confirmWrite: [], noDelete: [] },
       projects: {}
@@ -551,6 +574,7 @@ function handleRead(input: HookInput): void {
 // ========================================
 
 async function main(): Promise<void> {
+  await ensureYamlLoaded();
   let input: HookInput;
 
   try {


### PR DESCRIPTION
## Summary

- Replace the static `import 'yaml'` in `SecurityValidator.hook.ts` with a guarded `await import('yaml')`, so the missing `yaml` package no longer crashes the hook at module load.
- Hook now silently fails open (consistent with existing missing-patterns and parse-error paths) instead of emitting `Cannot find package 'yaml' from …` on every `PreToolUse:Read`.
- Runtime `~/.pai/hooks/` and shipped `Releases/v4.0.3+/.claude/hooks/` stay byte-identical.

## Test plan

- [x] `diff` runtime vs shipped → byte-identical
- [x] `echo JSON | bun run …SecurityValidator.hook.ts` for `{Read, Bash, Write}` tool inputs → all return `{"continue":true}` exit 0 with zero stderr
- [x] Failing-dynamic-import latency measured at ~10ms total per invocation (mostly Bun cold-start), well inside the 200ms stdin window
- [x] Audit of all 17 PAI hooks for third-party npm imports → only `SecurityValidator.hook.ts` uses any (`yaml`); no other hooks affected
- [x] `import type` erasure verified empirically — runtime test confirms no resolution attempt for the type-only import

## Out of scope (deeper finding — follow-up issue)

SecurityValidator has been silently a no-op since v4.x. Even with this fix, `parseYaml` remains `null` because Bun resolves dynamic imports relative to the script file, not cwd, and no `node_modules` exists at any ancestor of `~/.pai/hooks/`. Additionally, `patterns.example.yaml` stopped shipping after v3.0 and is absent from `Releases/v4.0.3+/`. Restoring real pattern matching needs both pieces. Filing follow-up issue.

Closes #156.