### PR TITLE
Extract shared engine/pai-paths.ts to dedupe migrator helpers

### DIFF
--- a/Releases/v4.0.3+/.claude/PAI-Install/engine/actions.ts
+++ b/Releases/v4.0.3+/.claude/PAI-Install/engine/actions.ts
@@ -18,6 +18,7 @@ import { migratePerPackCommands } from "./command-migration";
 import { migrateMemoryDirectory } from "./memory-migration";
 import { migratePaiRuntime } from "./pai-runtime-migration";
 import { tryExec } from "./exec";
+import { getPaiHome } from "./pai-paths";
 
 /**
  * Remove duplicate bun PATH entries from shell config.
@@ -591,14 +592,9 @@ export async function runRepository(
   // run before any subsequent step that might write new MEMORY state at
   // the canonical location. `paiDir` here is semantically the Claude Code
   // config root — same naming convention as the skill/command migrators.
-  {
-    let canonicalPaiHome = (process.env.PAI_DIR || "").trim();
-    if (canonicalPaiHome === "~" || canonicalPaiHome.startsWith("~/")) {
-      canonicalPaiHome = join(homedir(), canonicalPaiHome.slice(1));
-    }
-    if (!canonicalPaiHome) canonicalPaiHome = join(homedir(), ".pai");
-    await migrateMemoryDirectory(paiDir, canonicalPaiHome, emit);
-  }
+  // Uses the shared getPaiHome() resolver (#162) so the $HOME-prefix branch
+  // and any future env-var fixes apply here too.
+  await migrateMemoryDirectory(paiDir, getPaiHome(), emit);
 
   // Canonicalize each PAI-owned skill pack as a symlink from ~/.claude/skills
   // to ~/.pai/skills (GitHub #110). Runs on both fresh and upgrade paths:

--- a/Releases/v4.0.3+/.claude/PAI-Install/engine/command-migration.ts
+++ b/Releases/v4.0.3+/.claude/PAI-Install/engine/command-migration.ts
@@ -39,9 +39,9 @@ import {
   rmSync,
   cpSync,
 } from "fs";
-import { homedir } from "os";
 import { join, resolve, relative, basename } from "path";
 import type { EngineEventHandler } from "./types";
+import { getPaiCommandsDir, isJunkEntry } from "./pai-paths";
 
 export type CommandClassification =
   | "already-correct-symlink"
@@ -58,31 +58,10 @@ export interface CommandMigrationSummary {
   failed: number;
 }
 
-const IGNORED_ENTRIES = new Set([".DS_Store", ".gitkeep"]);
-const BACKUP_SUFFIX_RE = /\.backup-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z$/;
-
-function isIgnored(name: string): boolean {
-  if (IGNORED_ENTRIES.has(name)) return true;
-  if (name.startsWith("._")) return true;
-  if (BACKUP_SUFFIX_RE.test(name)) return true;
-  return false;
-}
-
-/**
- * Resolve the canonical PAI commands directory. Uses PAI_DIR env var if set
- * (test-mode override or custom install layout), otherwise defaults to
- * `~/.pai/commands`.
- */
-function getPaiCommandsDir(): string {
-  let envPaiDir = (process.env.PAI_DIR || "").trim();
-  if (envPaiDir === "~" || envPaiDir.startsWith("~/")) {
-    envPaiDir = join(homedir(), envPaiDir.slice(1));
-  } else if (envPaiDir.startsWith("$HOME")) {
-    envPaiDir = join(homedir(), envPaiDir.slice("$HOME".length));
-  }
-  const paiHome = envPaiDir || join(homedir(), ".pai");
-  return join(paiHome, "commands");
-}
+// Command-tree-specific extra junk: .gitkeep markers used to keep otherwise-
+// empty pack-source dirs tracked in git. Layered onto the shared base
+// (.DS_Store, ._*, backup-suffix) via isJunkEntry's extraEntries opt.
+const COMMAND_EXTRA_JUNK: ReadonlySet<string> = new Set([".gitkeep"]);
 
 /**
  * Enumerate top-level command filenames under `dir` that are real .md files
@@ -93,7 +72,7 @@ function collectOwnedFiles(dir: string): Set<string> {
   const out = new Set<string>();
   if (!existsSync(dir)) return out;
   for (const e of readdirSync(dir, { withFileTypes: true })) {
-    if (isIgnored(e.name)) continue;
+    if (isJunkEntry(e.name, { extraEntries: COMMAND_EXTRA_JUNK })) continue;
     if (!e.name.endsWith(".md")) continue;
     if (e.isFile() && !e.isSymbolicLink()) {
       out.add(e.name);
@@ -257,10 +236,10 @@ export async function migratePerPackCommands(
 
   const allNames = new Set<string>();
   for (const e of readdirSync(claudeCommandsDir, { withFileTypes: true })) {
-    if (!isIgnored(e.name) && e.name.endsWith(".md")) allNames.add(e.name);
+    if (!isJunkEntry(e.name, { extraEntries: COMMAND_EXTRA_JUNK }) && e.name.endsWith(".md")) allNames.add(e.name);
   }
   for (const e of readdirSync(paiCommandsDir, { withFileTypes: true })) {
-    if (!isIgnored(e.name) && e.name.endsWith(".md")) allNames.add(e.name);
+    if (!isJunkEntry(e.name, { extraEntries: COMMAND_EXTRA_JUNK }) && e.name.endsWith(".md")) allNames.add(e.name);
   }
 
   if (allNames.size === 0) {

--- a/Releases/v4.0.3+/.claude/PAI-Install/engine/pai-paths.ts
+++ b/Releases/v4.0.3+/.claude/PAI-Install/engine/pai-paths.ts
@@ -1,0 +1,111 @@
+/**
+ * PAI Installer v4.0 — Shared path helpers + junk-file predicate (GitHub #162).
+ *
+ * Extracted from three migration modules that each inlined byte-identical
+ * copies of the PAI_DIR resolver and the .DS_Store / `._*` / backup-suffix
+ * filter:
+ *   - skill-migration.ts (#110)
+ *   - command-migration.ts (#113)
+ *   - pai-runtime-migration.ts (#160)
+ *
+ * Behaviour-preserving by design. Each caller passes the options that
+ * reproduce its prior local behaviour exactly:
+ *   - skill-migration:   isJunkEntry(name)
+ *   - command-migration: isJunkEntry(name, { extraEntries: new Set([".gitkeep"]) })
+ *   - pai-runtime:       isJunkEntry(name, { allowBackups: true })
+ *
+ * The PAI_DIR resolver is the most-likely-to-need-future-fixing piece of the
+ * three duplicates (e.g., `${HOME}` literal, `~user` patterns, trailing-slash
+ * normalisation). Centralising it means a single fix lands everywhere.
+ */
+
+import { homedir } from "os";
+import { join, basename } from "path";
+
+/**
+ * Resolve the canonical PAI runtime root (`~/.pai` by default).
+ *
+ * Honours `PAI_DIR` env var with prefix expansion:
+ *   - Bare "~" or "~/..."   → expanded against `os.homedir()`
+ *   - "$HOME..."            → expanded against `os.homedir()`
+ *   - Anything else         → used verbatim
+ *   - Empty/whitespace/unset → falls back to `~/.pai`
+ *
+ * Read at every call (not cached) so test fixtures can mutate the env var
+ * between calls. This matches the behaviour of the prior inlined copies.
+ *
+ * NOTE: This is DIFFERENT from the installer's `paiDir` variable in actions.ts,
+ * which is misleadingly named and resolves to `~/.claude/`. `getPaiHome()`
+ * returns the `~/.pai/` runtime root, never the Claude config root.
+ */
+export function getPaiHome(): string {
+  let envPaiDir = (process.env.PAI_DIR || "").trim();
+  if (envPaiDir === "~" || envPaiDir.startsWith("~/")) {
+    envPaiDir = join(homedir(), envPaiDir.slice(1));
+  } else if (envPaiDir.startsWith("$HOME")) {
+    envPaiDir = join(homedir(), envPaiDir.slice("$HOME".length));
+  }
+  return envPaiDir || join(homedir(), ".pai");
+}
+
+/** `<paiHome>/skills` — canonical PAI skills directory. */
+export const getPaiSkillsDir = (): string => join(getPaiHome(), "skills");
+
+/** `<paiHome>/commands` — canonical PAI commands directory. */
+export const getPaiCommandsDir = (): string => join(getPaiHome(), "commands");
+
+/**
+ * Backup-file naming convention used by the migrators when resolving drift.
+ * Format: `<name>.backup-YYYY-MM-DDTHH-MM-SS-sssZ` (the output of
+ * `new Date().toISOString().replace(/[:.]/g, "-")` appended to the original
+ * basename). Skill and command migrators write these; pai-runtime doesn't.
+ *
+ * Kept private — callers should always go through `isJunkEntry` rather than
+ * reimplementing the regex.
+ */
+const BACKUP_SUFFIX_RE = /\.backup-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z$/;
+
+export interface IsJunkOpts {
+  /**
+   * Additional names to treat as junk on top of the always-junk set
+   * (`.DS_Store`, `._*`, backup-suffix). E.g. command-migration adds
+   * `.gitkeep` so empty-directory markers don't get symlinked.
+   */
+  extraEntries?: ReadonlySet<string>;
+
+  /**
+   * `true` → backup-suffix names are NOT treated as junk.
+   * `false` (default) → backup-suffix names ARE junk (skill+command behaviour:
+   *   they create backups during drift resolution and must skip them on
+   *   subsequent runs to avoid re-symlinking the backup directory).
+   *
+   * Used by pai-runtime-migration which copies a shipped tree that contains
+   * no backup files; the suffix exclusion would be a no-op there but is
+   * disabled explicitly for intent clarity.
+   */
+  allowBackups?: boolean;
+}
+
+/**
+ * Classify a basename as junk that should be skipped during dir enumeration
+ * or filtered out of `cpSync`. Pure function.
+ *
+ * Always-junk: `.DS_Store`, anything starting with `._` (macOS resource forks),
+ * and (unless `allowBackups: true`) names matching `BACKUP_SUFFIX_RE`.
+ */
+export function isJunkEntry(name: string, opts?: IsJunkOpts): boolean {
+  if (name === ".DS_Store") return true;
+  if (opts?.extraEntries?.has(name)) return true;
+  if (name.startsWith("._")) return true;
+  if (!opts?.allowBackups && BACKUP_SUFFIX_RE.test(name)) return true;
+  return false;
+}
+
+/**
+ * Build a `cpSync` filter predicate from `IsJunkOpts`. The returned function
+ * receives the absolute source path (per Node's `cpSync.filter` contract) and
+ * returns `true` to copy, `false` to skip.
+ */
+export function makeCpFilter(opts?: IsJunkOpts): (src: string) => boolean {
+  return (src: string) => !isJunkEntry(basename(src), opts);
+}

--- a/Releases/v4.0.3+/.claude/PAI-Install/engine/pai-runtime-migration.ts
+++ b/Releases/v4.0.3+/.claude/PAI-Install/engine/pai-runtime-migration.ts
@@ -34,47 +34,10 @@ import {
   copyFileSync,
   cpSync,
 } from "fs";
-import { homedir } from "os";
-import { join, basename } from "path";
+import { join } from "path";
 import type { EngineEventHandler } from "./types";
 import { tryExec, tryExecAt } from "./exec";
-
-const IGNORED_ENTRIES = new Set([".DS_Store"]);
-
-function isIgnored(name: string): boolean {
-  if (IGNORED_ENTRIES.has(name)) return true;
-  if (name.startsWith("._")) return true;
-  return false;
-}
-
-/**
- * `cpSync` filter: skip .DS_Store and macOS resource-fork `._*` files.
- * Applied at every filesystem copy to keep junk out of the canonical tree.
- */
-function cpFilter(src: string): boolean {
-  return !isIgnored(basename(src));
-}
-
-/**
- * Resolve the canonical PAI runtime directory (`~/.pai/`).
- * Uses PAI_DIR env var if set (test-mode override or custom install layout),
- * otherwise defaults to `~/.pai`. A `~/` or `$HOME/` prefix on the env var
- * value is expanded so user-supplied overrides work.
- *
- * This is DIFFERENT from the installer's `paiDir` variable in actions.ts,
- * which is misleadingly named and always resolves to `~/.claude/`. Pattern
- * inlined from skill-migration.ts (not exported there) to keep this module
- * self-contained.
- */
-function getPaiHomeDir(): string {
-  let envPaiDir = (process.env.PAI_DIR || "").trim();
-  if (envPaiDir === "~" || envPaiDir.startsWith("~/")) {
-    envPaiDir = join(homedir(), envPaiDir.slice(1));
-  } else if (envPaiDir.startsWith("$HOME")) {
-    envPaiDir = join(homedir(), envPaiDir.slice("$HOME".length));
-  }
-  return envPaiDir || join(homedir(), ".pai");
-}
+import { getPaiHome, makeCpFilter } from "./pai-paths";
 
 /**
  * Byte-compare two files. Returns true if both exist and have identical
@@ -302,7 +265,8 @@ async function materializePaiSecuritySystem(
       recursive: true,
       dereference: false,
       force: true,
-      filter: cpFilter,
+      // allowBackups: true — no-op for shipped tree (no backup files), explicit for intent.
+      filter: makeCpFilter({ allowBackups: true }),
     });
     await emit({
       event: "message",
@@ -344,7 +308,7 @@ export async function migratePaiRuntime(
   emit: EngineEventHandler,
 ): Promise<PaiRuntimeMigrationSummary> {
   const claudeRoot = paiDir;
-  const paiHome = getPaiHomeDir();
+  const paiHome = getPaiHome();
 
   const summary: PaiRuntimeMigrationSummary = {
     packageJsonAction: "source-absent",

--- a/Releases/v4.0.3+/.claude/PAI-Install/engine/skill-migration.ts
+++ b/Releases/v4.0.3+/.claude/PAI-Install/engine/skill-migration.ts
@@ -36,9 +36,9 @@ import {
   rmSync,
   cpSync,
 } from "fs";
-import { homedir } from "os";
 import { join, resolve, relative, basename } from "path";
 import type { EngineEventHandler } from "./types";
+import { getPaiSkillsDir, isJunkEntry, makeCpFilter } from "./pai-paths";
 
 export type PackClassification =
   | "already-correct-symlink"
@@ -61,40 +61,6 @@ export interface MigrationSummary {
 // handles their USER subdirs separately.
 const SKIP_SYSTEM_DIRS = new Set(["PAI", "CORE"]);
 
-const IGNORED_ENTRIES = new Set([".DS_Store"]);
-
-// Matches the backup suffix this module creates during drift resolution:
-// `<pack>.backup-YYYY-MM-DDTHH-MM-SS-sssZ`. Backups must be invisible to
-// subsequent migration runs so they don't get re-symlinked.
-const BACKUP_SUFFIX_RE = /\.backup-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z$/;
-
-function isIgnored(name: string): boolean {
-  if (IGNORED_ENTRIES.has(name)) return true;
-  if (name.startsWith("._")) return true;
-  if (BACKUP_SUFFIX_RE.test(name)) return true;
-  return false;
-}
-
-/**
- * Resolve the canonical PAI skills directory.
- * Uses PAI_DIR env var if set (test-mode override or custom install layout),
- * otherwise defaults to `~/.pai/skills`. A `~/` or `$HOME/` prefix on the
- * env var value is expanded so user-supplied overrides work.
- *
- * This is DIFFERENT from the installer's `paiDir` variable in actions.ts,
- * which is misleadingly named and always resolves to `~/.claude/`.
- */
-function getPaiSkillsDir(): string {
-  let envPaiDir = (process.env.PAI_DIR || "").trim();
-  if (envPaiDir === "~" || envPaiDir.startsWith("~/")) {
-    envPaiDir = join(homedir(), envPaiDir.slice(1));
-  } else if (envPaiDir.startsWith("$HOME")) {
-    envPaiDir = join(homedir(), envPaiDir.slice("$HOME".length));
-  }
-  const paiHome = envPaiDir || join(homedir(), ".pai");
-  return join(paiHome, "skills");
-}
-
 /**
  * Enumerate top-level pack names under `dir` that are real directories
  * (not symlinks, not ignored, not system dirs). Used to compute the PAI-owned
@@ -104,21 +70,13 @@ function getPaiSkillsDir(): string {
 function collectOwnedDirs(dir: string): Set<string> {
   const out = new Set<string>();
   for (const e of readdirSync(dir, { withFileTypes: true })) {
-    if (isIgnored(e.name)) continue;
+    if (isJunkEntry(e.name)) continue;
     if (SKIP_SYSTEM_DIRS.has(e.name)) continue;
     if (e.isDirectory() && !e.isSymbolicLink()) {
       out.add(e.name);
     }
   }
   return out;
-}
-
-/**
- * `cpSync` filter: skip .DS_Store and macOS resource-fork `._*` files.
- * Applied at every filesystem copy to keep junk out of the canonical tree.
- */
-function cpFilter(src: string): boolean {
-  return !isIgnored(basename(src));
 }
 
 /**
@@ -215,7 +173,7 @@ async function migratePack(
         // Cross-device or non-empty destination: filtered recursive copy + remove source.
         cpSync(claudeSide, paiSide, {
           recursive: true,
-          filter: cpFilter,
+          filter: makeCpFilter(),
           dereference: false,
         });
         rmSync(claudeSide, { recursive: true, force: true });
@@ -303,10 +261,10 @@ export async function migratePerPackSymlinks(
   // Iterate the union of both sides.
   const allNames = new Set<string>();
   for (const e of readdirSync(claudeSkillsDir, { withFileTypes: true })) {
-    if (!isIgnored(e.name)) allNames.add(e.name);
+    if (!isJunkEntry(e.name)) allNames.add(e.name);
   }
   for (const e of readdirSync(paiSkillsDir, { withFileTypes: true })) {
-    if (!isIgnored(e.name)) allNames.add(e.name);
+    if (!isJunkEntry(e.name)) allNames.add(e.name);
   }
 
   await emit({
@@ -369,5 +327,12 @@ export async function migratePerPackSymlinks(
   return summary;
 }
 
-// Exposed for tests only.
-export const __testInternals = { getPaiSkillsDir, cpFilter, isIgnored, migratePack };
+// Exposed for tests only. Re-exports of the shared `pai-paths` helpers
+// preserve back-compat with any consumer that pokes at __testInternals
+// (current in-tree tests do not, but external scripts may).
+export const __testInternals = {
+  getPaiSkillsDir,
+  cpFilter: makeCpFilter(),
+  isIgnored: isJunkEntry,
+  migratePack,
+};


### PR DESCRIPTION
## Summary

- Closes #162.
- New `engine/pai-paths.ts` exports `getPaiHome` / `getPaiSkillsDir` / `getPaiCommandsDir` resolvers, an `isJunkEntry(name, opts)` predicate, and a `makeCpFilter(opts)` factory.
- Each call site passes options that reproduce its prior local behaviour exactly:
  - `skill-migration.ts`: `isJunkEntry(name)` (default — backup-suffix is junk)
  - `command-migration.ts`: `isJunkEntry(name, { extraEntries: COMMAND_EXTRA_JUNK })` (`.gitkeep` extension)
  - `pai-runtime-migration.ts`: `makeCpFilter({ allowBackups: true })` (no backup-suffix matching, matching its prior local `isIgnored`)
  - `actions.ts`: `getPaiHome()` (replaces a 4th inlined copy that silently dropped the `$HOME...` prefix branch — latent bug closed as a side-benefit; surfaced by /simplify Reuse agent during review and approved as in-scope)
- Diff: −127 / +142 across 5 files; net behaviour-preserving dedup with one incidental bug fix.

## Out-of-scope follow-ups (not addressed here)

The /simplify review surfaced further duplication worth filing as separate issues:
- `migratePack` ↔ `migrateCommand` 80-line state machines (drift backup → renameSync+EXDEV/ENOTEMPTY fallback → symlinkSync rollback) — near-byte-identical
- Backup-timestamp formatter `new Date().toISOString().replace(/[:.]/g, "-")` duplicated in `skill-migration.ts:154` and `command-migration.ts:148`; lives next to `BACKUP_SUFFIX_RE` semantically
- `classifySkillDir` ↔ `classifyCommandFile` parallel structure
- `memory-migration.ts:88-94` `IGNORED_BASENAMES` + `isIgnoredName` could fold into `isJunkEntry({ extraEntries, allowBackups: true })`

## Test plan

- [x] \`bun test engine/skill-migration.test.ts engine/memory-migration.test.ts\` from \`Releases/v4.0.3+/.claude/PAI-Install/\` — **25 pass / 0 fail / 84 expect() calls**
- [x] grep for \`homedir\`, \`IGNORED_ENTRIES\`, \`BACKUP_SUFFIX_RE\`, local \`isIgnored\`, local resolvers across the four migration modules — **no inlined copies remain**
- [x] Public exports preserved: \`migratePerPackSymlinks\`, \`classifySkillDir\`, \`migratePerPackCommands\`, \`classifyCommandFile\`, \`migratePaiRuntime\`, plus \`__testInternals\` shape on \`skill-migration.ts\`
- [ ] \`Tools/verify-security-validator.sh\` — runtime-level test against \`~/.pai/\`; only meaningful after a fresh install. Not gating this PR.